### PR TITLE
Youtube feed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,5 +48,11 @@ coverage/
 
 # Rust / Tauri
 src-tauri/target/
+src-tauri/Cargo.lock
+src-tauri/gen/
+
+# Local notes and scratch files
+AGENTS.md
+docs/
 
 .cursor/

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ GitHub محدودیت استفاده در ساعت دارد
 - [JetBrains Mono](https://www.jetbrains.com/lp/mono/) - فونت monospace
 - [Lucide](https://lucide.dev) - آیکون‌ها
 
-تشکر ویژه از تمام توسعه‌دهندگان، از جمله apix7.
+تشکر ویژه از تمام توسعه‌دهندگان
 
 ## 🎯 حمایت از پروژه
 

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ GitHub محدودیت استفاده در ساعت دارد
 - [JetBrains Mono](https://www.jetbrains.com/lp/mono/) - فونت monospace
 - [Lucide](https://lucide.dev) - آیکون‌ها
 
-تشکر ویژه از تمام توسعه‌دهندگان.
+تشکر ویژه از تمام توسعه‌دهندگان، از جمله apix7.
 
 ## 🎯 حمایت از پروژه
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -7,20 +7,21 @@ license = "MIT"
 repository = ""
 default-run = "cns"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.77.2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-tauri-build = { version = "1.5.5", features = [] }
+tauri-build = { version = "2", features = [] }
 
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-tauri = { version = "1.8.1", features = [] }
+tauri = { version = "2", features = [] }
 keyring = "2.3.3"
 reqwest = { version = "0.12.8", default-features = false, features = ["rustls-tls"] }
 urlencoding = "2.1.3"
+base64 = "0.22.1"
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem and the built-in dev server is disabled.

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-  tauri_build::build()
+    tauri_build::build()
 }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "default",
+  "description": "Allow the main CNS window to call core IPC and app-defined commands.",
+  "windows": ["main"],
+  "permissions": ["core:default"]
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,11 +1,1036 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+use base64::{engine::general_purpose, Engine as _};
+use reqwest::header::{CACHE_CONTROL, CONTENT_TYPE, HOST, PRAGMA, USER_AGENT};
+use reqwest::Url;
+use serde::{Deserialize, Serialize};
+use std::collections::{hash_map::DefaultHasher, HashSet};
 use std::env;
 use std::fs;
+use std::hash::{Hash, Hasher};
 use std::io::Write;
+use std::net::{IpAddr, SocketAddr};
 use std::path::PathBuf;
 use tauri::Manager;
+
+const DEFAULT_INVIDIOUS_INSTANCE: &str = "https://invidious.tiekoetter.com";
+const TRANSLATE_FLAGS: &str = "_x_tr_sl=el&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp";
+const PRIMARY_FRONT_DOMAIN: &str = "mail.google.com";
+const PRIMARY_FRONT_IP: &str = "216.239.38.120";
+const FALLBACK_GOOGLE_FRONTS: [&str; 2] = ["www.google.com", "images.google.com"];
+const MAX_FEED_BODY_BYTES: u64 = 1024 * 1024;
+const MAX_IMAGE_BODY_BYTES: u64 = 3 * 1024 * 1024;
+const MAX_FEED_ITEMS: usize = 60;
+const MAX_SUBSCRIPTIONS_PER_FEED: usize = 20;
+const MAX_FEED_PAGE: u32 = 50;
+const ALLOWED_YOUTUBE_HOSTS: [&str; 5] = [
+    "youtube.com",
+    "www.youtube.com",
+    "m.youtube.com",
+    "music.youtube.com",
+    "youtu.be",
+];
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct YoutubeProxyHealth {
+    ok: bool,
+    message: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct YoutubeSubscription {
+    id: String,
+    kind: String,
+    label: String,
+    value: String,
+    channel_id: Option<String>,
+    thumbnail: Option<String>,
+    added_at: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct YoutubeFeedItem {
+    video_id: String,
+    title: String,
+    channel_title: String,
+    channel_id: Option<String>,
+    thumbnail_url: Option<String>,
+    published_at: Option<String>,
+    duration: Option<String>,
+    view_count_text: Option<String>,
+    source_id: Option<String>,
+    url: String,
+}
+
+fn validate_allowed_host(url: &Url, allowed_hosts: &[&str]) -> Result<(), String> {
+    match url.scheme() {
+        "https" => {}
+        _ => return Err("Only https URLs are allowed".to_string()),
+    }
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err("URLs with credentials are not allowed".to_string());
+    }
+    if url.port().is_some() {
+        return Err("Custom URL ports are not allowed".to_string());
+    }
+    let host = url
+        .host_str()
+        .ok_or_else(|| "Target URL missing host".to_string())?;
+    let host_l = host.trim_matches('.').to_ascii_lowercase();
+    if !allowed_hosts.iter().any(|allowed| *allowed == host_l) {
+        return Err(format!("Host {} is not allowed", host_l));
+    }
+    Ok(())
+}
+
+fn is_private_or_reserved_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v) => {
+            v.is_private()
+                || v.is_loopback()
+                || v.is_link_local()
+                || v.is_broadcast()
+                || v.is_documentation()
+                || v.octets()[0] == 0
+                || v.octets()[0] >= 224
+                || v.octets()[0] == 169 && v.octets()[1] == 254
+        }
+        IpAddr::V6(v) => {
+            v.is_loopback()
+                || v.is_unspecified()
+                || v.segments()[0] & 0xfe00 == 0xfc00
+                || v.segments()[0] & 0xffc0 == 0xfe80
+        }
+    }
+}
+
+fn validate_public_http_url(url: &Url) -> Result<(), String> {
+    match url.scheme() {
+        "https" => {}
+        _ => return Err("Only https targets are allowed".to_string()),
+    }
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err("URLs with credentials are not allowed".to_string());
+    }
+    if url.port().is_some() {
+        return Err("Custom URL ports are not allowed".to_string());
+    }
+    let host = url
+        .host_str()
+        .ok_or_else(|| "Target URL missing host".to_string())?;
+    let host_l = host.trim_matches('.').to_ascii_lowercase();
+    if host_l == "localhost"
+        || host_l.ends_with(".localhost")
+        || host_l.ends_with(".local")
+        || host_l == "metadata.google.internal"
+        || host_l == "169.254.169.254"
+        || host_l == "100.100.100.200"
+    {
+        return Err("Local or metadata hosts are not allowed".to_string());
+    }
+    if let Ok(ip) = host_l.parse::<IpAddr>() {
+        if is_private_or_reserved_ip(ip) {
+            return Err("Private or reserved IP targets are not allowed".to_string());
+        }
+    }
+    Ok(())
+}
+
+fn normalize_instance(instance: Option<String>) -> Result<Url, String> {
+    let raw = instance
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_INVIDIOUS_INSTANCE.to_string());
+    let mut url =
+        Url::parse(raw.trim()).map_err(|err| format!("Feed source URL is invalid: {}", err))?;
+    validate_public_http_url(&url)?;
+    url.set_username("").ok();
+    url.set_password(None).ok();
+    url.set_path("");
+    url.set_query(None);
+    url.set_fragment(None);
+    Ok(url)
+}
+
+fn sanitize_feed_page(page: Option<u32>) -> u32 {
+    page.unwrap_or(1).clamp(1, MAX_FEED_PAGE)
+}
+
+fn translated_host_for(target: &Url) -> Result<String, String> {
+    let host = target
+        .host_str()
+        .ok_or_else(|| "Target URL missing host".to_string())?;
+    Ok(format!("{}.translate.goog", host.replace('.', "-")))
+}
+
+fn translate_front_url(target: &Url, front: &str) -> Result<Url, String> {
+    validate_public_http_url(target)?;
+    let mut out = Url::parse(&format!("https://{}", front)).map_err(|err| err.to_string())?;
+    out.set_path(target.path());
+    let query = match target.query() {
+        Some(q) if !q.is_empty() => format!("{}&{}", q, TRANSLATE_FLAGS),
+        _ => TRANSLATE_FLAGS.to_string(),
+    };
+    out.set_query(Some(&query));
+    Ok(out)
+}
+
+fn translate_client(timeout_secs: u64) -> Result<reqwest::Client, String> {
+    let front_ip = PRIMARY_FRONT_IP
+        .parse::<IpAddr>()
+        .map_err(|err| format!("Feed route IP is invalid: {}", err))?;
+    let front_addr = SocketAddr::new(front_ip, 443);
+    reqwest::Client::builder()
+        .http1_only()
+        .resolve(PRIMARY_FRONT_DOMAIN, front_addr)
+        .redirect(reqwest::redirect::Policy::limited(5))
+        .connect_timeout(std::time::Duration::from_secs(5))
+        .timeout(std::time::Duration::from_secs(timeout_secs))
+        .build()
+        .map_err(|err| format!("Feed client failed: {}", err))
+}
+
+fn translate_fronts() -> Vec<&'static str> {
+    let mut fronts = Vec::with_capacity(1 + FALLBACK_GOOGLE_FRONTS.len());
+    fronts.push(PRIMARY_FRONT_DOMAIN);
+    fronts.extend(FALLBACK_GOOGLE_FRONTS);
+    fronts
+}
+
+async fn translate_fetch_bytes(
+    target: Url,
+    timeout_secs: u64,
+    max_bytes: u64,
+) -> Result<(Vec<u8>, Option<String>), String> {
+    validate_public_http_url(&target)?;
+    let translated_host = translated_host_for(&target)?;
+    let client = translate_client(timeout_secs)?;
+
+    let mut last_err = String::new();
+    for front in translate_fronts() {
+        let url = translate_front_url(&target, front)?;
+        match client
+            .get(url)
+            .header(HOST, translated_host.as_str())
+            .header(USER_AGENT, "Mozilla/5.0 CNS")
+            .header(PRAGMA, "no-cache")
+            .header(CACHE_CONTROL, "no-cache")
+            .send()
+            .await
+        {
+            Ok(resp) => {
+                if !resp.status().is_success() {
+                    last_err = format!("HTTP {}", resp.status());
+                    continue;
+                }
+                let content_type = resp
+                    .headers()
+                    .get(CONTENT_TYPE)
+                    .and_then(|value| value.to_str().ok())
+                    .map(|value| value.to_string());
+                let body = resp
+                    .bytes()
+                    .await
+                    .map_err(|err| format!("Feed read failed: {}", err))?;
+                if body.len() as u64 > max_bytes {
+                    return Err("Feed response is too large".to_string());
+                }
+                return Ok((body.to_vec(), content_type));
+            }
+            Err(err) => {
+                last_err = err.to_string();
+            }
+        }
+    }
+    Err(format!("Feed request failed: {}", last_err))
+}
+
+async fn translate_fetch_text(target: Url, timeout_secs: u64) -> Result<String, String> {
+    let (body, _) = translate_fetch_bytes(target, timeout_secs, MAX_FEED_BODY_BYTES).await?;
+    String::from_utf8(body).map_err(|err| format!("Feed body is not UTF-8: {}", err))
+}
+
+async fn fetch_text(target: Url, timeout_secs: u64) -> Result<String, String> {
+    translate_fetch_text(target, timeout_secs).await
+}
+
+fn join_instance_path(instance: &Url, path: &str) -> Result<Url, String> {
+    let allowed = [
+        "/api/v1/stats",
+        "/search",
+        "/channel/",
+    ];
+    if !allowed
+        .iter()
+        .any(|prefix| path == *prefix || path.starts_with(prefix))
+    {
+        return Err("Feed path is not available".to_string());
+    }
+    let mut out = instance.clone();
+    out.set_path(path);
+    out.set_query(None);
+    out.set_fragment(None);
+    validate_public_http_url(&out)?;
+    Ok(out)
+}
+
+fn is_valid_video_id(value: &str) -> bool {
+    value.len() == 11
+        && value
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_')
+}
+
+fn is_valid_channel_id(value: &str) -> bool {
+    value.len() == 24
+        && value.starts_with("UC")
+        && value
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_')
+}
+
+fn normalize_channel_subscription(
+    channel_id: &str,
+    label: String,
+    thumbnail: Option<String>,
+) -> YoutubeSubscription {
+    YoutubeSubscription {
+        id: format!("channel:{}", channel_id),
+        kind: "channel".to_string(),
+        label,
+        value: channel_id.to_string(),
+        channel_id: Some(channel_id.to_string()),
+        thumbnail,
+        added_at: now_iso(),
+    }
+}
+
+fn clean_text(value: &str) -> String {
+    value.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn normalized_text(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() {
+                ch.to_ascii_lowercase()
+            } else {
+                ' '
+            }
+        })
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn channel_match_score(input: &str, sub: &YoutubeSubscription) -> i32 {
+    let query = normalized_text(input);
+    let label = normalized_text(&sub.label);
+    let value = normalized_text(&sub.value);
+    let channel_id = sub
+        .channel_id
+        .as_deref()
+        .map(normalized_text)
+        .unwrap_or_default();
+    let handle = sub
+        .label
+        .split_whitespace()
+        .find(|part| part.starts_with('@'))
+        .map(normalized_text)
+        .unwrap_or_default();
+
+    if query.is_empty() {
+        return 0;
+    }
+    if label == query || value == query || channel_id == query || handle == query {
+        return 300;
+    }
+    if label.starts_with(&query) || value.starts_with(&query) || handle.starts_with(&query) {
+        return 220;
+    }
+    if label.contains(&query)
+        || value.contains(&query)
+        || channel_id.contains(&query)
+        || handle.contains(&query)
+    {
+        return 160;
+    }
+    if query.contains(&label) && !label.is_empty() {
+        return 120;
+    }
+    if query.contains(&value) && !value.is_empty() {
+        return 100;
+    }
+    0
+}
+
+fn merge_channel_label(title: String, handle: Option<String>) -> String {
+    let title = title.trim();
+    let handle = handle
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    match (title.is_empty(), handle) {
+        (false, Some(handle)) if !title.contains(&handle) => format!("{} {}", title, handle),
+        (false, _) => title.to_string(),
+        (true, Some(handle)) => handle,
+        (true, None) => String::new(),
+    }
+}
+
+fn choose_best_channel_subscription(
+    input: &str,
+    channels: Vec<YoutubeSubscription>,
+) -> Option<YoutubeSubscription> {
+    best_subscription_match(input, channels)
+}
+
+fn best_subscription_match(
+    input: &str,
+    items: impl IntoIterator<Item = YoutubeSubscription>,
+) -> Option<YoutubeSubscription> {
+    items
+        .into_iter()
+        .filter_map(|sub| {
+            let score = channel_match_score(input, &sub);
+            if score > 0 {
+                Some((score, sub))
+            } else {
+                None
+            }
+        })
+        .max_by_key(|(score, _)| *score)
+        .map(|(_, sub)| sub)
+}
+
+fn decode_html_entities(value: &str) -> String {
+    value
+        .replace("&amp;", "&")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+        .replace("&apos;", "'")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&nbsp;", " ")
+}
+
+fn strip_tags(value: &str) -> String {
+    let mut out = String::new();
+    let mut in_tag = false;
+    for ch in value.chars() {
+        match ch {
+            '<' => in_tag = true,
+            '>' => in_tag = false,
+            _ if !in_tag => out.push(ch),
+            _ => {}
+        }
+    }
+    clean_text(&decode_html_entities(&out))
+}
+
+fn attr_value(tag: &str, attr: &str) -> Option<String> {
+    let needle = format!("{}=", attr);
+    let start = tag.find(&needle)? + needle.len();
+    let rest = &tag[start..];
+    let quote = rest.chars().next()?;
+    if quote == '"' || quote == '\'' {
+        let value_start = quote.len_utf8();
+        let value_end = rest[value_start..].find(quote)? + value_start;
+        return Some(decode_html_entities(&rest[value_start..value_end]));
+    }
+    let value_end = rest
+        .find(|ch: char| ch.is_ascii_whitespace() || ch == '>')
+        .unwrap_or(rest.len());
+    Some(decode_html_entities(&rest[..value_end]))
+}
+
+fn floor_char_boundary(value: &str, mut index: usize) -> usize {
+    index = index.min(value.len());
+    while index > 0 && !value.is_char_boundary(index) {
+        index -= 1;
+    }
+    index
+}
+
+fn ceil_char_boundary(value: &str, mut index: usize) -> usize {
+    index = index.min(value.len());
+    while index < value.len() && !value.is_char_boundary(index) {
+        index += 1;
+    }
+    index
+}
+
+fn find_before_index(
+    haystack: &str,
+    end: usize,
+    needle: &str,
+    max_distance: usize,
+) -> Option<usize> {
+    let end = floor_char_boundary(haystack, end);
+    let start = floor_char_boundary(haystack, end.saturating_sub(max_distance));
+    let window = &haystack[start..end];
+    window.rfind(needle).map(|rel| start + rel)
+}
+
+fn find_after_index(
+    haystack: &str,
+    start: usize,
+    needle: &str,
+    max_distance: usize,
+) -> Option<usize> {
+    let start = floor_char_boundary(haystack, start);
+    let end = ceil_char_boundary(haystack, start.saturating_add(max_distance));
+    let window = &haystack[start..end];
+    window.find(needle).map(|rel| start + rel)
+}
+
+fn find_after<'a>(
+    haystack: &'a str,
+    start: usize,
+    needle: &str,
+    max_distance: usize,
+) -> Option<&'a str> {
+    let start = floor_char_boundary(haystack, start);
+    let end = ceil_char_boundary(haystack, start.saturating_add(max_distance));
+    let window = &haystack[start..end];
+    let rel = window.find(needle)?;
+    Some(&haystack[start + rel..end])
+}
+
+fn first_p_text_after_marker(fragment: &str, marker: &str) -> Option<String> {
+    let marker_start = fragment.find(marker)?;
+    let p_start = fragment[marker_start..].find("<p")? + marker_start;
+    let tag_end = fragment[p_start..].find('>')? + p_start + 1;
+    let close = fragment[tag_end..].find("</p>")? + tag_end;
+    let text = strip_tags(&fragment[tag_end..close]);
+    if text.is_empty() {
+        None
+    } else {
+        Some(text)
+    }
+}
+
+fn p_texts_after_marker(fragment: &str, marker: &str, limit: usize) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut cursor = 0;
+    while let Some(rel) = fragment[cursor..].find(marker) {
+        let p_start = cursor + rel;
+        let Some(tag_end_rel) = fragment[p_start..].find('>') else {
+            break;
+        };
+        let tag_end = p_start + tag_end_rel + 1;
+        let Some(close_rel) = fragment[tag_end..].find("</p>") else {
+            break;
+        };
+        let close = tag_end + close_rel;
+        let text = strip_tags(&fragment[tag_end..close]);
+        if !text.is_empty() {
+            out.push(text);
+            if out.len() >= limit {
+                break;
+            }
+        }
+        cursor = close + "</p>".len();
+    }
+    out
+}
+
+fn first_img_src(fragment: &str) -> Option<String> {
+    let img_start = fragment.find("<img")?;
+    let img_end = fragment[img_start..].find('>')? + img_start + 1;
+    let tag = &fragment[img_start..img_end];
+    attr_value(tag, "data-src").or_else(|| attr_value(tag, "src"))
+}
+
+fn tag_attr_at(fragment: &str, tag_start: usize, attr: &str) -> Option<String> {
+    let tag_end = fragment[tag_start..].find('>')? + tag_start + 1;
+    attr_value(&fragment[tag_start..tag_end], attr)
+}
+
+fn channel_id_from_href(href: &str) -> Option<String> {
+    let decoded = decode_html_entities(href);
+    if decoded.starts_with("/channel/") {
+        return decoded
+            .trim_start_matches("/channel/")
+            .split(|ch| ch == '/' || ch == '?' || ch == '#')
+            .next()
+            .filter(|value| is_valid_channel_id(value))
+            .map(str::to_string);
+    }
+    if decoded.starts_with("https://") {
+        let parsed = Url::parse(&decoded).ok()?;
+        let segments: Vec<_> = parsed
+            .path_segments()
+            .map(|s| s.collect())
+            .unwrap_or_default();
+        if let Some(pos) = segments.iter().position(|s| *s == "channel") {
+            return segments
+                .get(pos + 1)
+                .filter(|value| is_valid_channel_id(value))
+                .map(|value| (*value).to_string());
+        }
+    }
+    None
+}
+
+fn normalize_published_text(value: &str) -> String {
+    let trimmed = value.trim();
+    if trimmed
+        .get(..7)
+        .map(|prefix| prefix.eq_ignore_ascii_case("shared "))
+        .unwrap_or(false)
+    {
+        trimmed[7..].trim().to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn normalize_duration_text(value: &str) -> Option<String> {
+    let text = clean_text(value);
+    if text.is_empty() {
+        return None;
+    }
+    let normalized = text.to_ascii_lowercase();
+    if normalized.contains("video") || normalized.contains("views") || normalized.contains("watching") {
+        return None;
+    }
+    let mut parts = text.split(':');
+    let count = parts.by_ref().take(4).count();
+    if (2..=3).contains(&count)
+        && text
+            .chars()
+            .all(|ch| ch.is_ascii_digit() || ch == ':' || ch.is_ascii_whitespace())
+    {
+        Some(text)
+    } else {
+        None
+    }
+}
+
+fn image_cache_key(url: &Url) -> String {
+    let mut hasher = DefaultHasher::new();
+    url.as_str().hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}
+
+fn sniff_image_mime(bytes: &[u8]) -> Option<&'static str> {
+    if bytes.starts_with(&[0xff, 0xd8, 0xff]) {
+        return Some("image/jpeg");
+    }
+    if bytes.starts_with(b"\x89PNG\r\n\x1a\n") {
+        return Some("image/png");
+    }
+    if bytes.starts_with(b"GIF87a") || bytes.starts_with(b"GIF89a") {
+        return Some("image/gif");
+    }
+    if bytes.len() >= 12 && &bytes[0..4] == b"RIFF" && &bytes[8..12] == b"WEBP" {
+        return Some("image/webp");
+    }
+    None
+}
+
+fn mime_from_response(content_type: Option<&str>, bytes: &[u8]) -> Result<&'static str, String> {
+    if let Some(value) = content_type {
+        let mime = value.split(';').next().unwrap_or("").trim();
+        if mime.starts_with("image/") {
+            return Ok(match mime {
+                "image/jpeg" | "image/jpg" => "image/jpeg",
+                "image/png" => "image/png",
+                "image/gif" => "image/gif",
+                "image/webp" => "image/webp",
+                "image/bmp" => "image/bmp",
+                "image/svg+xml" => "image/svg+xml",
+                _ => "image/jpeg",
+            });
+        }
+    }
+    sniff_image_mime(bytes).ok_or_else(|| "Feed image is unavailable".to_string())
+}
+
+fn cached_image_path(window: &tauri::Window, url: &Url) -> Result<PathBuf, String> {
+    let app = window.app_handle();
+    let root = app
+        .path()
+        .app_cache_dir()
+        .or_else(|_| app.path().app_data_dir())
+        .or_else(|_| app.path().app_config_dir())
+        .map_err(|err| format!("Feed cache directory is unavailable: {}", err))?;
+    let dir = root.join("youtube-feed-images");
+    fs::create_dir_all(&dir)
+        .map_err(|err| format!("Feed cache directory could not be created: {}", err))?;
+    Ok(dir.join(format!("{}.img", image_cache_key(url))))
+}
+
+fn image_data_url(bytes: &[u8], content_type: Option<&str>) -> Result<String, String> {
+    let mime = mime_from_response(content_type, bytes)?;
+    Ok(format!(
+        "data:{};base64,{}",
+        mime,
+        general_purpose::STANDARD.encode(bytes)
+    ))
+}
+
+fn normalize_image_target(raw: &str, instance: Option<String>) -> Result<Url, String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err("Image URL is empty".to_string());
+    }
+    let url = if trimmed.starts_with("//") {
+        Url::parse(&format!("https:{}", trimmed)).map_err(|err| err.to_string())?
+    } else if trimmed.starts_with('/') {
+        normalize_instance(instance)?
+            .join(trimmed)
+            .map_err(|err| err.to_string())?
+    } else {
+        Url::parse(trimmed).map_err(|err| err.to_string())?
+    };
+    validate_public_http_url(&url)?;
+    Ok(url)
+}
+
+fn normalize_thumbnail_url(raw: &str, instance: &Url) -> Option<String> {
+    let value = raw.trim();
+    if value.is_empty() {
+        return None;
+    }
+    if value.starts_with("//") {
+        return Some(format!("https:{}", value));
+    }
+    if value.starts_with('/') {
+        return instance.join(value).ok().map(|url| url.to_string());
+    }
+    Url::parse(value)
+        .ok()
+        .filter(|url| url.scheme() == "https")
+        .map(|url| url.to_string())
+}
+
+fn video_id_from_href(href: &str) -> Option<String> {
+    let decoded = decode_html_entities(href);
+    let url = if decoded.starts_with("/watch") || decoded.starts_with("/playlist") {
+        Url::parse(&format!("https://www.youtube.com{}", decoded)).ok()?
+    } else if decoded.starts_with("https://") {
+        Url::parse(&decoded).ok()?
+    } else {
+        return None;
+    };
+    let id = if url.path().starts_with("/watch") {
+        url.query_pairs()
+            .find(|(name, _)| name == "v")
+            .map(|(_, value)| value.to_string())?
+    } else if url.path().starts_with("/playlist") {
+        url.query_pairs()
+            .find(|(name, _)| name == "list")
+            .map(|(_, value)| value.to_string())?
+    } else {
+        return None;
+    };
+    if is_valid_video_id(&id) {
+        Some(id)
+    } else {
+        None
+    }
+}
+
+fn channel_id_from_fragment(fragment: &str) -> Option<String> {
+    let mut cursor = 0;
+    while let Some(rel) = fragment[cursor..].find("/channel/UC") {
+        let start = cursor + rel + "/channel/".len();
+        let end = (start + 24).min(fragment.len());
+        let channel_id = &fragment[start..end];
+        if is_valid_channel_id(channel_id) {
+            return Some(channel_id.to_string());
+        }
+        cursor = end;
+    }
+    None
+}
+
+fn html_title_text(html: &str) -> Option<String> {
+    let start = html.find("<title>")? + "<title>".len();
+    let end = html[start..].find("</title>")? + start;
+    let title = strip_tags(&html[start..end])
+        .trim_end_matches(" - Invidious")
+        .trim_end_matches(" - YouTube")
+        .trim()
+        .to_string();
+    if title.is_empty() {
+        None
+    } else {
+        Some(title)
+    }
+}
+
+fn parse_invidious_html_feed(html: &str, instance: &Url, limit: usize) -> Vec<YoutubeFeedItem> {
+    let mut items = Vec::new();
+    let mut seen = HashSet::new();
+    let mut cursor = 0;
+
+    while let Some(href_rel) = html[cursor..].find("href=\"") {
+        let href_start = cursor + href_rel + "href=\"".len();
+        let Some(href_end_rel) = html[href_start..].find('"') else {
+            break;
+        };
+        let href_end = href_start + href_end_rel;
+        let href = &html[href_start..href_end];
+        cursor = href_end + 1;
+
+        let Some(video_id) = video_id_from_href(href) else {
+            continue;
+        };
+        if !seen.insert(video_id.clone()) {
+            continue;
+        }
+
+        let card_start = find_before_index(html, href_start, "<div class=\"h-box\"", 1800)
+            .or_else(|| find_before_index(html, href_start, "<div class=\"pure-u", 1800))
+            .unwrap_or(href_start.saturating_sub(1200));
+        let next_card = find_after_index(html, href_end, "<div class=\"h-box\"", 4500)
+            .or_else(|| find_after_index(html, href_end, "<div class=\"pure-u", 4500))
+            .unwrap_or((card_start + 4500).min(html.len()));
+        let card = &html[card_start..next_card.min(html.len())];
+
+        let title = first_p_text_after_marker(card, "video-card-row")
+            .or_else(|| {
+                find_after(html, href_end, "<p", 500).and_then(|fragment| {
+                    let p_start = fragment.find('>')? + 1;
+                    let p_end = fragment[p_start..].find("</p>")? + p_start;
+                    Some(strip_tags(&fragment[p_start..p_end]))
+                })
+            })
+            .filter(|title| !title.is_empty())
+            .unwrap_or_else(|| video_id.clone());
+
+        let channel_title = first_p_text_after_marker(card, "<p class=\"channel-name\"")
+            .or_else(|| {
+                let after = find_after(html, href_end, "<p class=\"channel-name\"", 1600)?;
+                let start = after.find('>')?;
+                let end = after[start + 1..].find("</p>")?;
+                Some(strip_tags(&after[start + 1..start + 1 + end]))
+            })
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| "YouTube".to_string());
+        let channel_id = channel_id_from_fragment(card).or_else(|| {
+            let after = find_after(html, href_end, "/channel/UC", 1800)?;
+            channel_id_from_fragment(after)
+        });
+        let thumbnail_url =
+            first_img_src(card).and_then(|src| normalize_thumbnail_url(&src, instance));
+        let duration = first_p_text_after_marker(card, "<p class=\"length\"")
+            .and_then(|text| normalize_duration_text(&text));
+        let metadata = p_texts_after_marker(card, "class=\"video-data\"", 4);
+        let view_count_text = metadata
+            .iter()
+            .find(|text| text.to_ascii_lowercase().contains("view"))
+            .cloned();
+        let published_at = metadata
+            .iter()
+            .find(|text| !text.to_ascii_lowercase().contains("view"))
+            .map(|text| normalize_published_text(text));
+
+        items.push(YoutubeFeedItem {
+            video_id: video_id.clone(),
+            title,
+            channel_title,
+            channel_id,
+            thumbnail_url,
+            published_at,
+            duration,
+            view_count_text,
+            source_id: None,
+            url: format!("https://www.youtube.com/watch?v={}", video_id),
+        });
+
+        if items.len() >= limit {
+            break;
+        }
+    }
+
+    items
+}
+
+fn parse_invidious_html_channels(
+    html: &str,
+    input: &str,
+    limit: usize,
+) -> Vec<YoutubeSubscription> {
+    let mut out = Vec::new();
+    let mut seen = HashSet::new();
+    let mut cursor = 0;
+
+    while let Some(channel_rel) = html[cursor..].find("/channel/UC") {
+        let href_marker = cursor + channel_rel;
+        let Some(anchor_start) = find_before_index(html, href_marker, "<a", 320) else {
+            cursor = href_marker + "/channel/".len();
+            continue;
+        };
+        let href = tag_attr_at(html, anchor_start, "href").unwrap_or_default();
+        let Some(channel_id) =
+            channel_id_from_href(&href).or_else(|| channel_id_from_fragment(&html[href_marker..]))
+        else {
+            cursor = href_marker + "/channel/".len();
+            continue;
+        };
+        cursor = href_marker + "/channel/".len();
+        let card_start = find_before_index(html, anchor_start, "<div class=\"h-box\"", 2400)
+            .or_else(|| find_before_index(html, anchor_start, "<div class=\"pure-u", 2400))
+            .unwrap_or(anchor_start.saturating_sub(1600));
+        let card_end = find_after_index(html, anchor_start, "<div class=\"pure-u", 4200)
+            .or_else(|| find_after_index(html, anchor_start, "<div class=\"h-box\"", 4200))
+            .unwrap_or((anchor_start + 4200).min(html.len()));
+        let card = &html[card_start..card_end.min(html.len())];
+        if video_id_from_href(&href).is_some() || card.contains("href=\"/watch") {
+            continue;
+        }
+        if !seen.insert(channel_id.clone()) {
+            continue;
+        }
+
+        let title = first_p_text_after_marker(card, "video-card-row")
+            .or_else(|| first_p_text_after_marker(card, "<p class=\"channel-name\""))
+            .unwrap_or_else(|| input.to_string());
+        let handle = p_texts_after_marker(card, "class=\"channel-name\"", 3)
+            .into_iter()
+            .find(|text| text.trim_start().starts_with('@'));
+        let label = merge_channel_label(title, handle);
+
+        let label = if label.is_empty() {
+            input.to_string()
+        } else {
+            label
+        };
+
+        out.push(normalize_channel_subscription(&channel_id, label, None));
+
+        if out.len() >= limit {
+            break;
+        }
+    }
+
+    out
+}
+
+fn now_iso() -> String {
+    match std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
+        Ok(d) => format!("{}", d.as_secs()),
+        Err(_) => "0".to_string(),
+    }
+}
+
+async fn invidious_search_html(
+    instance: &Url,
+    query: &str,
+    search_type: &str,
+    limit: usize,
+    page: u32,
+) -> Result<Vec<YoutubeFeedItem>, String> {
+    let mut url = join_instance_path(instance, "/search")?;
+    url.query_pairs_mut()
+        .append_pair("q", query)
+        .append_pair("type", search_type)
+        .append_pair("page", &page.to_string());
+    let html = fetch_text(url, 14).await?;
+    Ok(parse_invidious_html_feed(&html, instance, limit))
+}
+
+async fn invidious_channel_search_html(
+    instance: &Url,
+    query: &str,
+    limit: usize,
+    page: u32,
+) -> Result<Vec<YoutubeSubscription>, String> {
+    let mut url = join_instance_path(instance, "/search")?;
+    url.query_pairs_mut()
+        .append_pair("q", query)
+        .append_pair("type", "channel")
+        .append_pair("page", &page.to_string());
+    let html = fetch_text(url, 14).await?;
+    let channels = parse_invidious_html_channels(&html, query, limit.saturating_mul(4));
+    Ok(match choose_best_channel_subscription(query, channels) {
+        Some(best) => vec![best],
+        None => Vec::new(),
+    })
+}
+
+async fn invidious_channel_videos_html(
+    instance: &Url,
+    channel_id: &str,
+    page: u32,
+) -> Result<Vec<YoutubeFeedItem>, String> {
+    let path = format!("/channel/{}/videos", channel_id);
+    let mut url = join_instance_path(instance, &path)?;
+    url.query_pairs_mut().append_pair("page", &page.to_string());
+    let html = fetch_text(url, 14).await?;
+    Ok(parse_invidious_html_feed(&html, instance, 18))
+}
+
+async fn invidious_channel_subscription_html(
+    instance: &Url,
+    channel_id: &str,
+) -> Result<YoutubeSubscription, String> {
+    if !is_valid_channel_id(channel_id) {
+        return Err("Invalid channel id".to_string());
+    }
+    let path = format!("/channel/{}", channel_id);
+    let url = join_instance_path(instance, &path)?;
+    let html = fetch_text(url, 14).await?;
+    let label = html_title_text(&html).unwrap_or_else(|| channel_id.to_string());
+    Ok(normalize_channel_subscription(channel_id, label, None))
+}
+
+async fn resolve_channel_id_subscription(
+    instance: &Url,
+    channel_id: &str,
+) -> Result<YoutubeSubscription, String> {
+    invidious_channel_subscription_html(instance, channel_id).await
+}
+
+async fn resolve_channel_search(
+    instance: &Url,
+    _match_input: &str,
+    query: &str,
+) -> Option<YoutubeSubscription> {
+    if let Ok(channels) = invidious_channel_search_html(instance, query, 1, 1).await {
+        if let Some(sub) = channels.into_iter().next() {
+            return Some(sub);
+        }
+    }
+
+    None
+}
+
+fn scoped_channel_items(channel_id: &str, mut items: Vec<YoutubeFeedItem>) -> Vec<YoutubeFeedItem> {
+    items.retain(|item| {
+        item.channel_id
+            .as_deref()
+            .map(|item_channel_id| item_channel_id == channel_id)
+            .unwrap_or(true)
+    });
+    for item in &mut items {
+        if item.channel_id.is_none() {
+            item.channel_id = Some(channel_id.to_string());
+        }
+    }
+    items
+}
+
+fn subscription_channel_id(sub: &YoutubeSubscription) -> Option<&str> {
+    sub.channel_id
+        .as_deref()
+        .filter(|value| is_valid_channel_id(value))
+        .or_else(|| {
+            let value = sub.value.as_str();
+            if is_valid_channel_id(value) {
+                Some(value)
+            } else {
+                None
+            }
+        })
+}
 
 #[tauri::command]
 fn export_logs_to_file(window: tauri::Window, content: String) -> Result<String, String> {
@@ -26,7 +1051,8 @@ fn export_logs_to_file(window: tauri::Window, content: String) -> Result<String,
 
     fn ensure_dir(path: &PathBuf) -> Result<(), String> {
         if let Some(dir) = path.parent() {
-            fs::create_dir_all(dir).map_err(|err| format!("Failed to create directory {}: {}", dir.display(), err))
+            fs::create_dir_all(dir)
+                .map_err(|err| format!("Failed to create directory {}: {}", dir.display(), err))
         } else {
             Err("Failed to determine parent directory".to_string())
         }
@@ -34,7 +1060,8 @@ fn export_logs_to_file(window: tauri::Window, content: String) -> Result<String,
 
     fn write_file(path: PathBuf, content: &str) -> Result<PathBuf, String> {
         ensure_dir(&path)?;
-        let mut file = fs::File::create(&path).map_err(|err| format!("Failed to create {}: {}", path.display(), err))?;
+        let mut file = fs::File::create(&path)
+            .map_err(|err| format!("Failed to create {}: {}", path.display(), err))?;
         file.write_all(content.as_bytes())
             .map_err(|err| format!("Failed to write {}: {}", path.display(), err))?;
         Ok(path)
@@ -52,13 +1079,22 @@ fn export_logs_to_file(window: tauri::Window, content: String) -> Result<String,
         Ok(path) => return Ok(path.to_string_lossy().to_string()),
         Err(install_err) => {
             let app_dir = app
-                .path_resolver()
+                .path()
                 .app_data_dir()
-                .or_else(|| app.path_resolver().app_config_dir())
-                .ok_or_else(|| format!("Install write failed: {}; app data dir unavailable", install_err))?;
+                .or_else(|_| app.path().app_config_dir())
+                .map_err(|_| {
+                    format!(
+                        "Install write failed: {}; app data dir unavailable",
+                        install_err
+                    )
+                })?;
             let fallback_file = unique_file_path(app_dir.join("cns-startup-log.json"));
-            let path = write_file(fallback_file.clone(), &content)
-                .map_err(|fallback_err| format!("Install write failed: {}; fallback write failed: {}", install_err, fallback_err))?;
+            let path = write_file(fallback_file.clone(), &content).map_err(|fallback_err| {
+                format!(
+                    "Install write failed: {}; fallback write failed: {}",
+                    install_err, fallback_err
+                )
+            })?;
             return Ok(path.to_string_lossy().to_string());
         }
     }
@@ -123,11 +1159,12 @@ async fn download_github_file(
     if !response.status().is_success() {
         return Err(format!("E_HTTP_{}: download failed", response.status()));
     }
-    let resolver = window.app_handle().path_resolver();
-    let mut target = tauri::api::path::download_dir()
-        .or_else(|| resolver.app_data_dir())
-        .or_else(|| resolver.app_config_dir())
-        .ok_or_else(|| "E_DIR_RESOLVE: cannot resolve writable directory".to_string())?;
+    let resolver = window.app_handle().path();
+    let mut target = resolver
+        .download_dir()
+        .or_else(|_| resolver.app_data_dir())
+        .or_else(|_| resolver.app_config_dir())
+        .map_err(|_| "E_DIR_RESOLVE: cannot resolve writable directory".to_string())?;
     if let Err(err) = fs::create_dir_all(&target) {
         return Err(format!("E_DIR_CREATE: {}: {}", target.display(), err));
     }
@@ -155,20 +1192,225 @@ async fn download_github_file(
     output
         .flush()
         .map_err(|err| format!("E_FILE_FLUSH: {}: {}", tmp_path.display(), err))?;
-    fs::rename(&tmp_path, &target)
-        .map_err(|err| format!("E_FILE_RENAME: {} -> {}: {}", tmp_path.display(), target.display(), err))?;
+    fs::rename(&tmp_path, &target).map_err(|err| {
+        format!(
+            "E_FILE_RENAME: {} -> {}: {}",
+            tmp_path.display(),
+            target.display(),
+            err
+        )
+    })?;
     Ok(target.to_string_lossy().to_string())
 }
 
+#[tauri::command]
+async fn yt_proxy_health(instance: Option<String>) -> Result<YoutubeProxyHealth, String> {
+    let instance = normalize_instance(instance)?;
+    let mut url = join_instance_path(&instance, "/api/v1/stats")?;
+    url.set_query(None);
+    match translate_fetch_text(url, 10).await {
+        Ok(_) => Ok(YoutubeProxyHealth {
+            ok: true,
+            message: None,
+        }),
+        Err(err) => Ok(YoutubeProxyHealth {
+            ok: false,
+            message: Some(err),
+        }),
+    }
+}
+
+#[tauri::command]
+async fn yt_proxy_search(
+    query: String,
+    instance: Option<String>,
+    page: Option<u32>,
+) -> Result<Vec<YoutubeFeedItem>, String> {
+    let q = query.trim();
+    if q.is_empty() {
+        return Ok(Vec::new());
+    }
+    let instance = normalize_instance(instance)?;
+    let page = sanitize_feed_page(page);
+    invidious_search_html(&instance, q, "video", 36, page).await
+}
+
+#[tauri::command]
+async fn yt_proxy_resolve_subscription(
+    input: String,
+    instance: Option<String>,
+) -> Result<YoutubeSubscription, String> {
+    let raw = input.trim();
+    if raw.is_empty() {
+        return Err("Subscription input is empty".to_string());
+    }
+    let instance = normalize_instance(instance)?;
+    let instance_host = instance.host_str().unwrap_or_default().to_ascii_lowercase();
+
+    if raw.starts_with("UC") && raw.len() >= 20 {
+        if !is_valid_channel_id(raw) {
+            return Err("Invalid channel id".to_string());
+        }
+        return resolve_channel_id_subscription(&instance, raw)
+            .await
+            .or_else(|_| Ok(normalize_channel_subscription(raw, raw.to_string(), None)));
+    }
+
+    if let Ok(parsed) = Url::parse(raw) {
+        validate_public_http_url(&parsed)?;
+        let host = parsed.host_str().unwrap_or_default().to_ascii_lowercase();
+        if !(ALLOWED_YOUTUBE_HOSTS.iter().any(|allowed| *allowed == host) || host == instance_host)
+        {
+            return Err(format!("Host {} is not allowed", host));
+        }
+        if host != instance_host {
+            validate_allowed_host(&parsed, &ALLOWED_YOUTUBE_HOSTS)?;
+        }
+        {
+            let segments: Vec<_> = parsed
+                .path_segments()
+                .map(|s| s.collect())
+                .unwrap_or_default();
+            if let Some(pos) = segments.iter().position(|s| *s == "channel") {
+                if let Some(channel_id) = segments.get(pos + 1) {
+                    if is_valid_channel_id(channel_id) {
+                        return resolve_channel_id_subscription(&instance, channel_id)
+                            .await
+                            .or_else(|_| {
+                                Ok(normalize_channel_subscription(
+                                    channel_id,
+                                    (*channel_id).to_string(),
+                                    None,
+                                ))
+                            });
+                    }
+                    return Err("Invalid channel id".to_string());
+                }
+            }
+            if let Some(first) = segments.first() {
+                if first.starts_with('@') {
+                    let handle = first.trim_start_matches('@');
+                    let match_input = first.trim_start_matches('@');
+                    if let Some(sub) = resolve_channel_search(&instance, match_input, handle).await
+                    {
+                        return Ok(sub);
+                    }
+                    return Err("YouTube channel could not be resolved".to_string());
+                }
+            }
+        }
+        return Err("Expected a YouTube channel URL, handle, or channel id".to_string());
+    }
+
+    let search_query = raw.trim_start_matches('@');
+    if let Some(sub) = resolve_channel_search(&instance, search_query, search_query).await {
+        return Ok(sub);
+    }
+
+    Err("YouTube channel could not be resolved".to_string())
+}
+
+#[tauri::command]
+async fn yt_proxy_subscription_feed(
+    subscriptions: Vec<YoutubeSubscription>,
+    instance: Option<String>,
+    page: Option<u32>,
+) -> Result<Vec<YoutubeFeedItem>, String> {
+    let instance = normalize_instance(instance)?;
+    let page = sanitize_feed_page(page);
+    let mut groups: Vec<Vec<YoutubeFeedItem>> = Vec::new();
+    for sub in subscriptions.iter().take(MAX_SUBSCRIPTIONS_PER_FEED) {
+        let mut items = if sub.kind == "channel" {
+            match subscription_channel_id(sub) {
+                Some(channel_id) => {
+                    let items = invidious_channel_videos_html(&instance, channel_id, page)
+                        .await
+                        .unwrap_or_default();
+                    scoped_channel_items(channel_id, items)
+                }
+                _ => Vec::new(),
+            }
+        } else {
+            invidious_search_html(&instance, &sub.value, "video", 12, page)
+                .await
+                .unwrap_or_default()
+        };
+        for item in &mut items {
+            item.source_id = Some(sub.id.clone());
+        }
+        if !items.is_empty() {
+            groups.push(items);
+        }
+    }
+
+    let mut out: Vec<YoutubeFeedItem> = Vec::new();
+    let mut index = 0;
+    loop {
+        let mut pushed = false;
+        for group in &groups {
+            if let Some(item) = group.get(index) {
+                out.push(item.clone());
+                pushed = true;
+                if out.len() >= MAX_FEED_ITEMS * 2 {
+                    break;
+                }
+            }
+        }
+        if !pushed || out.len() >= MAX_FEED_ITEMS * 2 {
+            break;
+        }
+        index += 1;
+    }
+
+    let mut seen = HashSet::new();
+    out.retain(|item| seen.insert(item.video_id.clone()));
+    out.truncate(MAX_FEED_ITEMS);
+    Ok(out)
+}
+
+#[tauri::command]
+async fn yt_proxy_image(
+    window: tauri::Window,
+    url: String,
+    instance: Option<String>,
+) -> Result<String, String> {
+    let target = normalize_image_target(&url, instance)?;
+    let path = cached_image_path(&window, &target)?;
+    if let Ok(bytes) = fs::read(&path) {
+        if !bytes.is_empty() {
+            return image_data_url(&bytes, None);
+        }
+    }
+
+    let (bytes, content_type) = translate_fetch_bytes(target, 12, MAX_IMAGE_BODY_BYTES).await?;
+    let data_url = image_data_url(&bytes, content_type.as_deref())?;
+    let tmp_path = path.with_extension("part");
+    fs::write(&tmp_path, &bytes)
+        .map_err(|err| format!("Feed image cache write failed: {}", err))?;
+    fs::rename(&tmp_path, &path)
+        .or_else(|_| {
+            fs::write(&path, &bytes)?;
+            let _ = fs::remove_file(&tmp_path);
+            Ok::<(), std::io::Error>(())
+        })
+        .map_err(|err| format!("Feed image cache update failed: {}", err))?;
+    Ok(data_url)
+}
+
 fn main() {
-  tauri::Builder::default()
-    .invoke_handler(tauri::generate_handler![
-      export_logs_to_file,
-      set_secure_github_token,
-      get_secure_github_token,
-      clear_secure_github_token,
-      download_github_file
-    ])
-    .run(tauri::generate_context!())
-    .expect("error while running tauri application");
+    tauri::Builder::default()
+        .invoke_handler(tauri::generate_handler![
+            export_logs_to_file,
+            set_secure_github_token,
+            get_secure_github_token,
+            clear_secure_github_token,
+            download_github_file,
+            yt_proxy_health,
+            yt_proxy_search,
+            yt_proxy_resolve_subscription,
+            yt_proxy_subscription_feed,
+            yt_proxy_image
+        ])
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,63 +1,17 @@
 {
-  "$schema": "../node_modules/@tauri-apps/cli/schema.json",
+  "$schema": "https://schema.tauri.app/config/2",
+  "productName": "CNS",
+  "version": "1.2.2",
+  "identifier": "com.cns.app",
   "build": {
     "beforeBuildCommand": "npm run build",
     "beforeDevCommand": "npm run dev",
-    "devPath": "http://localhost:3000",
-    "distDir": "../dist",
-    "withGlobalTauri": true
+    "devUrl": "http://localhost:3000",
+    "frontendDist": "../dist"
   },
-  "package": {
-    "productName": "CNS",
-    "version": "1.2.2"
-  },
-  "tauri": {
-    "allowlist": {
-      "all": false
-    },
-    "bundle": {
-      "active": true,
-      "category": "Utility",
-      "copyright": "Copyright (c) CNS Contributors",
-      "deb": {
-        "depends": []
-      },
-      "externalBin": [],
-      "icon": [
-        "icons/32x32.png",
-        "icons/128x128.png",
-        "icons/128x128@2x.png",
-        "icons/icon.icns",
-        "icons/icon.ico"
-      ],
-      "identifier": "com.cns.app",
-      "longDescription": "CNS wraps the existing React UI in a native Tauri shell so non-technical users can run the app as a desktop executable instead of installing Node.js and starting a local dev server.",
-      "macOS": {
-        "entitlements": null,
-        "exceptionDomain": "",
-        "frameworks": [],
-        "providerShortName": null,
-        "signingIdentity": null
-      },
-      "publisher": "CNS",
-      "resources": [],
-      "shortDescription": "Native desktop shell for CNS",
-      "targets": "all",
-      "windows": {
-        "certificateThumbprint": null,
-        "digestAlgorithm": "sha256",
-        "timestampUrl": null,
-        "webviewInstallMode": {
-          "type": "offlineInstaller",
-          "silent": true
-        }
-      }
-    },
+  "app": {
     "security": {
       "csp": null
-    },
-    "updater": {
-      "active": false
     },
     "windows": [
       {
@@ -71,6 +25,39 @@
         "title": "CNS",
         "width": 1440
       }
-    ]
+    ],
+    "withGlobalTauri": true
+  },
+  "bundle": {
+    "active": true,
+    "category": "Utility",
+    "copyright": "Copyright (c) CNS Contributors",
+    "externalBin": [],
+    "icon": [
+      "icons/32x32.png",
+      "icons/128x128.png",
+      "icons/128x128@2x.png",
+      "icons/icon.icns",
+      "icons/icon.ico"
+    ],
+    "linux": {
+      "deb": {
+        "depends": []
+      }
+    },
+    "longDescription": "CNS wraps the existing React UI in a native Tauri shell so non-technical users can run the app as a desktop executable instead of installing Node.js and starting a local dev server.",
+    "publisher": "CNS",
+    "resources": [],
+    "shortDescription": "Native desktop shell for CNS",
+    "targets": "all",
+    "windows": {
+      "certificateThumbprint": null,
+      "digestAlgorithm": "sha256",
+      "timestampUrl": null,
+      "webviewInstallMode": {
+        "type": "offlineInstaller",
+        "silent": true
+      }
+    }
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { Settings, AlertCircle, X } from 'lucide-react';
+import { Settings, AlertCircle, X, DownloadCloud, Youtube } from 'lucide-react';
 import { fa } from './lib/i18n';
 import { github, DownloadJob } from './lib/github';
 import { logger } from './lib/logger';
 import { cn } from './lib/utils';
 import { InputNode } from './components/InputNode';
 import { SignalFeed } from './components/SignalFeed';
+import { YouTubeFeed } from './components/YouTubeFeed';
 import { SettingsModal } from './components/SettingsModal';
 import { MatrixRain } from './components/MatrixRain';
 import { AsciiLogo } from './components/AsciiLogo';
@@ -14,8 +15,28 @@ import { toPersianErrorMessage } from './lib/errors';
 import { subscribeUserToast } from './lib/userToast';
 
 const JOBS_STORAGE_KEY = 'cns_download_jobs';
+const APP_MODE_STORAGE_KEY = 'cns_app_mode';
 const MAX_STORED_JOBS = 30;
 const MAX_STORED_JOB_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+type AppMode = 'console' | 'youtube-feed';
+
+function loadStoredAppMode(): AppMode {
+  try {
+    return localStorage.getItem(APP_MODE_STORAGE_KEY) === 'youtube-feed'
+      ? 'youtube-feed'
+      : 'console';
+  } catch {
+    return 'console';
+  }
+}
+
+function saveStoredAppMode(mode: AppMode) {
+  try {
+    localStorage.setItem(APP_MODE_STORAGE_KEY, mode);
+  } catch {
+  }
+}
 
 function loadStoredJobs(): DownloadJob[] {
   try {
@@ -63,6 +84,7 @@ function summarizeJobsForSupport(jobs: DownloadJob[]) {
 function App() {
   const [jobs, setJobs] = useState<DownloadJob[]>(loadStoredJobs);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+  const [appMode, setAppMode] = useState<AppMode>(loadStoredAppMode);
   const [hasConfig, setHasConfig] = useState(false);
   const [initError, setInitError] = useState<string | null>(null);
   const [networkError, setNetworkError] = useState<string | null>(null);
@@ -92,6 +114,11 @@ function App() {
   }, []);
 
   const archive = useArchive({ enabled: hasConfig });
+  const isYoutubeFeedMode = appMode === 'youtube-feed';
+
+  useEffect(() => {
+    saveStoredAppMode(appMode);
+  }, [appMode]);
 
   useEffect(() => {
     logger.registerSupportContext(() => ({
@@ -229,30 +256,65 @@ function App() {
       <div className="shell-grid" />
       <div className="shell-glow" />
 
-      <aside className="cookie-warning" dir="rtl">
-        <AlertCircle size={15} />
-        <div>
-          <strong>یادآوری کوکی یوتیوب</strong>
-          <p>
-            یوتیوب هر چند ساعت کوکی‌ها را عوض می‌کند. اگر دانلود گیر کرد یا خطا داد،
-            کوکی‌های جدید را از مرورگر بگیرید و دوباره در تنظیمات وارد کنید.
-          </p>
-        </div>
-      </aside>
+      {!isYoutubeFeedMode && (
+        <aside className="cookie-warning" dir="rtl">
+          <AlertCircle size={15} />
+          <div>
+            <strong>یادآوری کوکی یوتیوب</strong>
+            <p>
+              یوتیوب هر چند ساعت کوکی‌ها را عوض می‌کند. اگر دانلود گیر کرد یا خطا داد،
+              کوکی‌های جدید را از مرورگر بگیرید و دوباره در تنظیمات وارد کنید.
+            </p>
+          </div>
+        </aside>
+      )}
 
-      <div className="relative z-10 mx-auto max-w-3xl">
+      <div className={cn('app-shell relative z-10 mx-auto', isYoutubeFeedMode && 'feed-mode')}>
         <header className="reclip-header">
-          <AsciiLogo />
-          <button
-            type="button"
-            onClick={() => setIsSettingsOpen(true)}
-            className={cn('settings-cog', !hasConfig && 'warn')}
-            aria-label={fa.actions.settings}
-            title={fa.actions.settings}
-          >
-            <Settings size={16} />
-            <span>تنظیمات</span>
-          </button>
+          {!isYoutubeFeedMode && <AsciiLogo />}
+          <div className="app-top-controls">
+            {!hasConfig && !initError && (
+              <button
+                type="button"
+                onClick={() => setIsSettingsOpen(true)}
+                className="settings-notice-chip"
+                title="تنظیمات لازم است"
+              >
+                <AlertCircle size={13} />
+                <span>تنظیمات لازم است</span>
+              </button>
+            )}
+            <div className="app-mode-switch" role="tablist" aria-label="حالت برنامه">
+              <button
+                type="button"
+                onClick={() => setAppMode('console')}
+                className={cn('app-mode-btn', appMode === 'console' && 'active')}
+                aria-pressed={appMode === 'console'}
+              >
+                <DownloadCloud size={15} />
+                <span>کنسول</span>
+              </button>
+              <button
+                type="button"
+                onClick={() => setAppMode('youtube-feed')}
+                className={cn('app-mode-btn', isYoutubeFeedMode && 'active')}
+                aria-pressed={isYoutubeFeedMode}
+              >
+                <Youtube size={15} />
+                <span>فید یوتیوب</span>
+              </button>
+            </div>
+            <button
+              type="button"
+              onClick={() => setIsSettingsOpen(true)}
+              className={cn('settings-cog', !hasConfig && 'warn')}
+              aria-label={fa.actions.settings}
+              title={fa.actions.settings}
+            >
+              <Settings size={16} />
+              <span>تنظیمات</span>
+            </button>
+          </div>
         </header>
 
         {initError && (
@@ -273,36 +335,34 @@ function App() {
           </div>
         )}
 
-        {!hasConfig && !initError && (
-          <div className="config-banner" dir="ltr">
-            <AlertCircle size={14} />
-            <span>توکن گیت‌هاب و کوکی‌های یوتیوب را در تنظیمات وارد کنید</span>
-            <button
-              type="button"
-              onClick={() => setIsSettingsOpen(true)}
-              className="config-banner-btn"
-            >
-              <Settings size={12} />
-              <span>{fa.actions.settings}</span>
-            </button>
-          </div>
+        {isYoutubeFeedMode ? (
+          <YouTubeFeed
+            onAddPending={handleAddPendingJob}
+            onPatchJob={handlePatchJob}
+            hasConfig={hasConfig}
+            networkError={networkError}
+            downloadBusy={downloadBusy}
+            archiveItems={archive.items}
+          />
+        ) : (
+          <InputNode
+            onAddPending={handleAddPendingJob}
+            onPatchJob={handlePatchJob}
+            hasActiveJob={downloadBusy}
+            disabled={!hasConfig || !!networkError}
+            downloadBusy={downloadBusy}
+            archiveItems={archive.items}
+          />
         )}
 
-        <InputNode
-          onAddPending={handleAddPendingJob}
-          onPatchJob={handlePatchJob}
-          hasActiveJob={downloadBusy}
-          disabled={!hasConfig || !!networkError}
-          downloadBusy={downloadBusy}
-          archiveItems={archive.items}
-        />
-
-        <SignalFeed
-          jobs={jobs}
-          onUpdate={handleJobUpdate}
-          onRemoveJob={handleJobRemove}
-          archive={archive}
-        />
+        {(!isYoutubeFeedMode || jobs.length > 0 || archive.items.length > 0) && (
+          <SignalFeed
+            jobs={jobs}
+            onUpdate={handleJobUpdate}
+            onRemoveJob={handleJobRemove}
+            archive={archive}
+          />
+        )}
       </div>
 
       <SettingsModal

--- a/src/components/InputNode.tsx
+++ b/src/components/InputNode.tsx
@@ -143,7 +143,7 @@ function advancedSubmitKey(a: DownloadAdvancedOptions): string {
 
 export function InputNode({ onAddPending, onPatchJob, hasActiveJob, disabled, downloadBusy, archiveItems = [] }: InputNodeProps) {
   const [text, setText] = useState('');
-  const [quality, setQuality] = useState<string>('best');
+  const [quality, setQuality] = useState<string>('480p');
   const [format, setFormat] = useState<string>('mp4');
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/src/components/InputNode.tsx
+++ b/src/components/InputNode.tsx
@@ -10,15 +10,14 @@ import {
 import { ClipboardPaste, Download, SlidersHorizontal } from 'lucide-react';
 import {
   DownloadJob,
-  github,
   DEFAULT_DOWNLOAD_ADVANCED,
   type DownloadAdvancedOptions,
 } from '../lib/github';
 import { cn } from '../lib/utils';
 import { toPersianErrorMessage } from '../lib/errors';
-import { logger } from '../lib/logger';
 import { fa } from '../lib/i18n';
 import type { ArchiveItem } from '../lib/useArchive';
+import { useDownloadSubmit } from '../lib/useDownloadSubmit';
 
 type AdvancedPopoverPanel = null | 'open' | 'closing';
 
@@ -42,7 +41,6 @@ const QUALITIES = [
   { value: '720p', label: '720P' },
   { value: '480p', label: '480P' },
 ] as const;
-const COOKIE_HASH_KEY = 'cns_cookie_hash_v1';
 const ADVANCED_STORAGE_KEY = 'cns_advanced_download_v2';
 
 function parseSingleUrl(raw: string): string | null {
@@ -55,53 +53,6 @@ function parseSingleUrl(raw: string): string | null {
   } catch {
     return null;
   }
-}
-
-function urlContentKey(raw: string): string {
-  try {
-    const u = new URL(raw.trim());
-    const host = u.hostname.replace(/^www\./i, '').toLowerCase();
-    if (host === 'youtu.be') {
-      const id = u.pathname.split('/').filter(Boolean)[0] || '';
-      return id ? `yt:${id}` : `url:${u.origin}${u.pathname}${u.search}`;
-    }
-    if (host === 'youtube.com' || host.endsWith('.youtube.com')) {
-      if (u.pathname === '/watch') {
-        const v = u.searchParams.get('v') || '';
-        if (v) return `yt:${v}`;
-      }
-      const p = u.pathname.split('/').filter(Boolean);
-      if (p[0] === 'shorts' && p[1]) return `yt:${p[1]}`;
-      if (p[0] === 'live' && p[1]) return `yt:${p[1]}`;
-    }
-    u.hash = '';
-    return `url:${u.toString()}`;
-  } catch {
-    return `raw:${raw.trim()}`;
-  }
-}
-
-async function fetchOembed(url: string): Promise<DownloadJob['meta']> {
-  try {
-    const resp = await fetch(`https://noembed.com/embed?url=${encodeURIComponent(url)}`);
-    if (!resp.ok) return undefined;
-    const data = await resp.json();
-    if (data?.error) return undefined;
-    return {
-      title: data.title,
-      channel: data.author_name,
-      thumbnail: data.thumbnail_url,
-    };
-  } catch {
-    return undefined;
-  }
-}
-
-async function sha1Hex(input: string): Promise<string> {
-  const digest = await crypto.subtle.digest('SHA-1', new TextEncoder().encode(input));
-  return Array.from(new Uint8Array(digest))
-    .map((b) => b.toString(16).padStart(2, '0'))
-    .join('');
 }
 
 function normalizeAdvanced(raw: unknown): DownloadAdvancedOptions {
@@ -137,17 +88,12 @@ function saveAdvancedToStorage(a: DownloadAdvancedOptions) {
   }
 }
 
-function advancedSubmitKey(a: DownloadAdvancedOptions): string {
-  return `${a.container}|${a.codec}|${a.bitrate}`;
-}
-
 export function InputNode({ onAddPending, onPatchJob, hasActiveJob, disabled, downloadBusy, archiveItems = [] }: InputNodeProps) {
   const [text, setText] = useState('');
   const [quality, setQuality] = useState<string>('480p');
   const [format, setFormat] = useState<string>('mp4');
-  const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const inFlightRef = useState(() => new Set<string>())[0];
+  const { submitDownload, isSubmitting } = useDownloadSubmit({ onAddPending, onPatchJob });
   const [advanced, setAdvanced] = useState<DownloadAdvancedOptions>(() => loadAdvancedFromStorage());
   const [advancedPanel, setAdvancedPanel] = useState<AdvancedPopoverPanel>(null);
   const advancedWrapRef = useRef<HTMLDivElement | null>(null);
@@ -235,121 +181,19 @@ export function InputNode({ onAddPending, onPatchJob, hasActiveJob, disabled, do
       setError('یک لینک https معتبر وارد کنید (بدون چند لینک یا خط جدید)');
       return;
     }
-    const currentKey = urlContentKey(url);
-    const exists = archiveItems.some((a) => {
-      const original = a.metadata?.original_url;
-      if (!original) return false;
-      return urlContentKey(original) === currentKey;
-    });
-    if (exists) {
-      setError('این ویدیو قبلا دانلود شده و داخل آرشیو موجود است.');
-      return;
-    }
-
-    const config = github.getConfig();
-    if (!config) {
-      setError('توکن گیت‌هاب تنظیم نشده است');
-      return;
-    }
-    const net = await github.probeNetwork();
-    if (!net.ok) {
-      if (net.code === 'AUTH') {
-        setError('توکن گیت‌هاب رد شد (۴۰۱). در تنظیمات دوباره ذخیره کنید.');
-      } else {
-        setError('اتصال شبکه به GitHub برقرار نیست. فایروال/ DNS یا پروکسی سیستم را بررسی کنید.');
-      }
-      return;
-    }
-
-    const effectiveQuality = isMp3 ? 'audio' : quality;
-    const effectiveFormat = isMp3 ? 'mp3' : 'mp4';
-    const adv = dispatchAdvanced;
-    const submitKey = `${url}|${effectiveQuality}|${effectiveFormat}|${advancedSubmitKey(adv)}`;
-    if (inFlightRef.has(submitKey)) return;
-    setIsLoading(true);
     setError(null);
-
     try {
-      logger.info('[Download] Submit started', {
-        format,
-        quality,
-        advanced: adv,
-      });
-      const cookieHealth = github.assessStoredCookies();
-      if (!cookieHealth.ok) {
-        throw new Error(cookieHealth.reason || 'COOKIE_EXPIRED_LOCAL');
-      }
-      const cookies = github.getCookies();
-      if (cookies) {
-        const cookieHash = await sha1Hex(cookies);
-        const uploadedHash = sessionStorage.getItem(COOKIE_HASH_KEY);
-        if (uploadedHash !== cookieHash) {
-          await github.uploadCookies(cookies);
-          sessionStorage.setItem(COOKIE_HASH_KEY, cookieHash);
-        }
-      }
-
-      inFlightRef.add(submitKey);
-      const nowIso = new Date().toISOString();
-      const jobId = crypto.randomUUID();
-      const baseJob: DownloadJob = {
-        id: jobId,
+      await submitDownload({
         url,
-        quality: effectiveQuality,
-        format: effectiveFormat,
-        advanced: { ...adv },
-        status: 'pending',
-        progress: 0,
-        logs: [`[${new Date().toLocaleTimeString('fa-IR')}] صف شد`],
-        createdAt: nowIso,
-        submitKey,
-      };
-      onAddPending(baseJob);
-      const metaTask = fetchOembed(url);
-
-      try {
-        const dispatch = await github.triggerWorkflowFast(url, effectiveQuality, effectiveFormat, adv);
-        const fetchedMeta = await metaTask;
-        const logs = [`[${new Date().toLocaleTimeString('fa-IR')}] صف شد`, `[${new Date().toLocaleTimeString('fa-IR')}] ارسال به گیت‌هاب انجام شد`];
-        onPatchJob(jobId, {
-          dispatchAt: dispatch.dispatchAt,
-          runHint: dispatch.runHint,
-          logs,
-          meta: fetchedMeta,
-        });
-        logger.info('[Download] Workflow dispatched', {
-          format: effectiveFormat,
-          quality: effectiveQuality,
-          advanced: adv,
-        });
-        setText('');
-        logger.info('[Download] Submit finished', {
-          format: effectiveFormat,
-          quality: isMp3 ? 'audio' : quality,
-        });
-      } catch (err) {
-        logger.error('[Download] Dispatch failed', {
-          error: err,
-          format: effectiveFormat,
-          quality: effectiveQuality,
-        });
-        const message = toPersianErrorMessage(err);
-        const fetchedMeta = await metaTask.catch(() => undefined);
-        onPatchJob(jobId, {
-          status: 'failed',
-          progress: 0,
-          logs: [`[${new Date().toLocaleTimeString('fa-IR')}] صف شد`, `[${new Date().toLocaleTimeString('fa-IR')}] ${message}`],
-          meta: fetchedMeta,
-        });
-        setError(`${message}`);
-      } finally {
-        inFlightRef.delete(submitKey);
-      }
+        quality: isMp3 ? 'audio' : quality,
+        format: isMp3 ? 'mp3' : 'mp4',
+        source: 'youtube',
+        advanced: dispatchAdvanced,
+        archiveItems,
+      });
+      setText('');
     } catch (err) {
-      logger.error('[Download] Submit aborted', { error: err });
       setError(toPersianErrorMessage(err));
-    } finally {
-      setIsLoading(false);
     }
   };
 
@@ -360,7 +204,7 @@ export function InputNode({ onAddPending, onPatchJob, hasActiveJob, disabled, do
     }
   };
 
-  const formLocked = disabled || isLoading || downloadBusy;
+  const formLocked = disabled || isSubmitting || downloadBusy;
 
   const handlePasteFromClipboard = async () => {
     if (formLocked) return;
@@ -545,7 +389,7 @@ export function InputNode({ onAddPending, onPatchJob, hasActiveJob, disabled, do
           className="fetch-button"
         >
           <Download size={16} />
-          <span>{isLoading ? '...در حال دریافت' : 'دریافت'}</span>
+          <span>{isSubmitting ? '...در حال دریافت' : 'دریافت'}</span>
         </button>
 
         <div

--- a/src/components/SignalFeed.tsx
+++ b/src/components/SignalFeed.tsx
@@ -6,7 +6,6 @@ import {
   FileAudio,
   Package,
   AlertTriangle,
-  Loader2,
   RefreshCw,
 } from 'lucide-react';
 import { fa } from '../lib/i18n';
@@ -800,16 +799,6 @@ export function SignalFeed({ jobs, onUpdate, onRemoveJob, archive }: SignalFeedP
   }, [jobs, archive.items]);
 
   if (cards.length === 0) {
-    if (archive.isLoading && !archive.hasLoadedOnce) {
-      return (
-        <div className="results-empty">
-          <Loader2 size={20} className="animate-spin opacity-70" />
-          <span dir="ltr" className="opacity-70">
-            ...در حال بررسی
-          </span>
-        </div>
-      );
-    }
     return (
       <div className="results-empty">
         <span dir="ltr">لینک یوتیوب را وارد کنید و دکمه دریافت را بزنید</span>

--- a/src/components/YouTubeFeed.tsx
+++ b/src/components/YouTubeFeed.tsx
@@ -1,0 +1,1002 @@
+import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  AlertCircle,
+  Download,
+  ImageOff,
+  Loader2,
+  Plus,
+  RefreshCw,
+  Search,
+  Trash2,
+  X,
+} from 'lucide-react';
+import {
+  DEFAULT_DOWNLOAD_ADVANCED,
+  DownloadJob,
+  type DownloadAdvancedOptions,
+} from '../lib/github';
+import { cn } from '../lib/utils';
+import type { ArchiveItem } from '../lib/useArchive';
+import { toPersianErrorMessage } from '../lib/errors';
+import { useDownloadSubmit } from '../lib/useDownloadSubmit';
+import {
+  isYoutubeProxyAvailable,
+  loadYoutubeProxySettings,
+  loadYoutubeSubscriptions,
+  saveYoutubeSubscriptions,
+  youtubeProxyImage,
+  youtubeProxyResolveSubscription,
+  youtubeProxySearch,
+  youtubeProxySubscriptionFeed,
+  type YouTubeFeedItem,
+  type YouTubeSubscription,
+} from '../lib/youtubeProxy';
+
+interface YouTubeFeedProps {
+  onAddPending: (job: DownloadJob) => void;
+  onPatchJob: (jobId: string, updates: Partial<DownloadJob>) => void;
+  hasConfig: boolean;
+  networkError: string | null;
+  downloadBusy: boolean;
+  archiveItems: ArchiveItem[];
+}
+
+const QUALITIES = [
+  { value: '480p', label: '480P' },
+  { value: '720p', label: '720P' },
+  { value: '1080p', label: '1080P' },
+  { value: 'best', label: 'BEST' },
+] as const;
+
+const FORMATS = [
+  { value: 'mp4', label: 'MP4' },
+  { value: 'mp3', label: 'MP3' },
+] as const;
+
+const FEED_TIMELINE_STORAGE_KEY = 'cns_youtube_feed_timeline_v1';
+const FEED_TIMELINE_NEW_TTL_MS = 72 * 60 * 60 * 1000;
+
+function youtubeWatchUrl(videoId: string) {
+  return `https://www.youtube.com/watch?v=${encodeURIComponent(videoId)}`;
+}
+
+function itemKey(item: YouTubeFeedItem) {
+  return item.videoId || item.url;
+}
+
+function slugForSubscription(value: string) {
+  return value.trim().toLowerCase().replace(/\s+/g, '-');
+}
+
+function isValidChannelId(value?: string) {
+  return /^UC[A-Za-z0-9_-]{22}$/.test(value?.trim() ?? '');
+}
+
+function channelIdForSubscription(sub: YouTubeSubscription) {
+  const channelId = sub.channelId?.trim() || (sub.kind === 'channel' ? sub.value.trim() : '');
+  return isValidChannelId(channelId) ? channelId : '';
+}
+
+function normalizeSubscriptionForState(sub: YouTubeSubscription): YouTubeSubscription {
+  const label = sub.label.trim() || sub.value.trim() || sub.channelId?.trim() || 'کانال';
+  const channelId = channelIdForSubscription(sub);
+  if (sub.kind === 'channel' && channelId) {
+    return {
+      ...sub,
+      id: `channel:${channelId}`,
+      kind: 'channel',
+      label,
+      value: channelId,
+      channelId,
+    };
+  }
+  if (sub.kind === 'channel') {
+    const value = sub.value.trim() || label;
+    return {
+      ...sub,
+      id: sub.id || `channel:${slugForSubscription(value)}`,
+      kind: 'channel',
+      label,
+      value,
+      channelId: undefined,
+    };
+  }
+  const value = sub.value.trim() || label;
+  return {
+    ...sub,
+    id: sub.id.startsWith('search:') ? sub.id : `search:${slugForSubscription(value)}`,
+    kind: 'search',
+    label,
+    value,
+    channelId: undefined,
+  };
+}
+
+function subscriptionDedupeKey(sub: YouTubeSubscription) {
+  const normalized = normalizeSubscriptionForState(sub);
+  if (normalized.kind === 'channel') {
+    return `channel:${normalized.channelId ?? normalized.value}`.toLowerCase();
+  }
+  return `search:${normalized.value.trim().toLowerCase()}`;
+}
+
+function subscriptionsEqual(a: YouTubeSubscription[], b: YouTubeSubscription[]) {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+function subscriptionKeyForList(items: YouTubeSubscription[]) {
+  return items.map((sub) => `${sub.id}:${sub.value}`).join('|');
+}
+
+type FeedTimelineMemory = {
+  sources: Record<string, string[]>;
+  newVideoIds: Record<string, string>;
+};
+
+function safeParse<T>(raw: string | null, fallback: T): T {
+  if (!raw) return fallback;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+function normalizeTimelineMemory(raw: unknown): FeedTimelineMemory {
+  if (!raw || typeof raw !== 'object') {
+    return { sources: {}, newVideoIds: {} };
+  }
+  const value = raw as Record<string, unknown>;
+  const sourcesRaw = value.sources && typeof value.sources === 'object' ? value.sources as Record<string, unknown> : {};
+  const newRaw = value.newVideoIds && typeof value.newVideoIds === 'object' ? value.newVideoIds as Record<string, unknown> : {};
+  const sources: Record<string, string[]> = {};
+  Object.entries(sourcesRaw).forEach(([key, entry]) => {
+    if (!Array.isArray(entry)) return;
+    sources[key] = entry.filter((id): id is string => typeof id === 'string' && id.length > 0).slice(0, 160);
+  });
+  const newVideoIds: Record<string, string> = {};
+  Object.entries(newRaw).forEach(([key, entry]) => {
+    if (typeof entry !== 'string' || entry.length === 0) return;
+    newVideoIds[key] = entry;
+  });
+  return { sources, newVideoIds };
+}
+
+function loadFeedTimelineMemory(): FeedTimelineMemory {
+  try {
+    return normalizeTimelineMemory(safeParse(localStorage.getItem(FEED_TIMELINE_STORAGE_KEY), null));
+  } catch {
+    return { sources: {}, newVideoIds: {} };
+  }
+}
+
+function saveFeedTimelineMemory(memory: FeedTimelineMemory) {
+  try {
+    localStorage.setItem(FEED_TIMELINE_STORAGE_KEY, JSON.stringify(memory));
+  } catch {
+  }
+}
+
+function sourceKeyForItem(item: YouTubeFeedItem): string | null {
+  if (item.sourceId && item.sourceId.trim()) return item.sourceId.trim();
+  if (item.channelId && item.channelId.trim()) return `channel:${item.channelId.trim()}`;
+  return null;
+}
+
+function mergeUnique(ids: string[], existing: string[]) {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const id of ids) {
+    if (!id || seen.has(id)) continue;
+    out.push(id);
+    seen.add(id);
+  }
+  for (const id of existing) {
+    if (!id || seen.has(id)) continue;
+    out.push(id);
+    seen.add(id);
+  }
+  return out.slice(0, 160);
+}
+
+function mergeFeedItems(existing: YouTubeFeedItem[], incoming: YouTubeFeedItem[]) {
+  const seen = new Set(existing.map(itemKey));
+  const items = [...existing];
+  let added = 0;
+  incoming.forEach((item) => {
+    const key = itemKey(item);
+    if (!key || seen.has(key)) return;
+    seen.add(key);
+    items.push(item);
+    added += 1;
+  });
+  return { items, added };
+}
+
+function pruneNewVideoIds(newVideoIds: Record<string, string>) {
+  const now = Date.now();
+  const entries = Object.entries(newVideoIds)
+    .filter(([, seenAt]) => {
+      const ts = Date.parse(seenAt);
+      return Number.isFinite(ts) && now - ts <= FEED_TIMELINE_NEW_TTL_MS;
+    })
+    .sort((a, b) => Date.parse(b[1]) - Date.parse(a[1]));
+  return Object.fromEntries(entries.slice(0, 240));
+}
+
+function normalizeAdvancedForFormat(format: string, adv: DownloadAdvancedOptions): DownloadAdvancedOptions {
+  if (format === 'mp3') {
+    return { ...adv, container: 'default', codec: 'copy', bitrate: 'auto' };
+  }
+  if (adv.codec === 'copy') {
+    return { ...adv, bitrate: 'auto' };
+  }
+  return adv;
+}
+
+export function YouTubeFeed({
+  onAddPending,
+  onPatchJob,
+  hasConfig,
+  networkError,
+  downloadBusy,
+  archiveItems,
+}: YouTubeFeedProps) {
+  const proxyAvailable = isYoutubeProxyAvailable();
+  const [settings] = useState(() => loadYoutubeProxySettings());
+  const [subscriptions, setSubscriptions] = useState<YouTubeSubscription[]>(() => loadYoutubeSubscriptions());
+  const [query, setQuery] = useState('');
+  const [activeQuery, setActiveQuery] = useState('');
+  const [activeSourceId, setActiveSourceId] = useState<string | null>(null);
+  const [transientSource, setTransientSource] = useState<YouTubeSubscription | null>(null);
+  const [subscriptionInput, setSubscriptionInput] = useState('');
+  const [items, setItems] = useState<YouTubeFeedItem[]>([]);
+  const [imageCache, setImageCache] = useState<Record<string, string>>({});
+  const [failedImages, setFailedImages] = useState<Record<string, true>>({});
+  const [timelineMemory, setTimelineMemory] = useState<FeedTimelineMemory>(() => loadFeedTimelineMemory());
+  const [selected, setSelected] = useState<YouTubeFeedItem | null>(null);
+  const [quality, setQuality] = useState<string>('480p');
+  const [format, setFormat] = useState<string>('mp4');
+  const [advanced] = useState<DownloadAdvancedOptions>(() => DEFAULT_DOWNLOAD_ADVANCED);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(true);
+  const [isAdding, setIsAdding] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [drawerError, setDrawerError] = useState<string | null>(null);
+  const loadRequestRef = useRef(0);
+  const migrationRequestRef = useRef(0);
+  const loadingMoreRef = useRef(false);
+  const loadMoreRef = useRef<HTMLDivElement | null>(null);
+  const firstTimelineLoadRef = useRef(true);
+  const lastAutoLoadKeyRef = useRef('');
+  const { submitDownload, isSubmitting } = useDownloadSubmit({ onAddPending, onPatchJob });
+
+  const canUseProxy = proxyAvailable;
+  const downloadDisabled = !hasConfig || !!networkError || downloadBusy || isSubmitting;
+  const subscriptionKey = useMemo(() => subscriptionKeyForList(subscriptions), [subscriptions]);
+  const activeViewLabel = activeQuery.trim()
+    ? 'نتایج جستجو'
+    : activeSourceId
+      ? subscriptions.find((sub) => sub.id === activeSourceId)?.label ?? transientSource?.label ?? 'فید ذخیره‌شده'
+      : 'فید همه کانال‌ها';
+  const normalizedAdvanced = useMemo(
+    () => normalizeAdvancedForFormat(format, advanced),
+    [advanced, format]
+  );
+
+  useEffect(() => {
+    const normalized = subscriptions.map(normalizeSubscriptionForState);
+    if (!subscriptionsEqual(subscriptions, normalized)) {
+      setSubscriptions(normalized);
+      return;
+    }
+    saveYoutubeSubscriptions(normalized);
+  }, [subscriptions]);
+
+  useEffect(() => {
+    if (!canUseProxy) return;
+    const candidates = subscriptions.filter((sub) => {
+      if (sub.kind === 'search') return sub.value.trim();
+      return !channelIdForSubscription(sub) && (sub.value.trim() || sub.label.trim());
+    });
+    if (candidates.length === 0) return;
+    const requestId = migrationRequestRef.current + 1;
+    migrationRequestRef.current = requestId;
+    let cancelled = false;
+
+    const run = async () => {
+      const resolvedById = new Map<string, YouTubeSubscription>();
+      for (const sub of candidates.slice(0, 8)) {
+        if (cancelled || requestId !== migrationRequestRef.current) return;
+        try {
+          const input = sub.value.trim() || sub.label.trim();
+          const resolved = normalizeSubscriptionForState(
+            await youtubeProxyResolveSubscription(input, settings.instance)
+          );
+          if (resolved.kind === 'channel') {
+            resolvedById.set(sub.id, { ...resolved, addedAt: sub.addedAt || resolved.addedAt });
+          }
+        } catch {
+        }
+      }
+      if (cancelled || resolvedById.size === 0 || requestId !== migrationRequestRef.current) return;
+      setSubscriptions((prev) => {
+        const seen = new Set<string>();
+        const next = prev
+          .map((sub) => resolvedById.get(sub.id) ?? sub)
+          .map(normalizeSubscriptionForState)
+          .filter((sub) => {
+            const key = subscriptionDedupeKey(sub);
+            if (seen.has(key)) return false;
+            seen.add(key);
+            return true;
+          });
+        return subscriptionsEqual(prev, next) ? prev : next;
+      });
+    };
+
+    void run();
+    return () => {
+      cancelled = true;
+    };
+  }, [canUseProxy, settings.instance, subscriptions]);
+
+  useEffect(() => {
+    saveFeedTimelineMemory(timelineMemory);
+  }, [timelineMemory]);
+
+  const rememberTimeline = useCallback((nextItems: YouTubeFeedItem[]) => {
+    setTimelineMemory((prev) => {
+      const firstLoad = firstTimelineLoadRef.current;
+      firstTimelineLoadRef.current = false;
+      const now = new Date().toISOString();
+      const sources = { ...prev.sources };
+      const newVideoIds = pruneNewVideoIds(prev.newVideoIds);
+      const idsBySource = new Map<string, string[]>();
+
+      nextItems.forEach((item) => {
+        const sourceKey = sourceKeyForItem(item);
+        if (!sourceKey) return;
+        const key = itemKey(item);
+        if (!key) return;
+        const list = idsBySource.get(sourceKey) ?? [];
+        list.push(key);
+        idsBySource.set(sourceKey, list);
+      });
+
+      idsBySource.forEach((ids, sourceKey) => {
+        const previousIds = sources[sourceKey] ?? [];
+        if (!firstLoad && previousIds.length > 0) {
+          ids.forEach((id) => {
+            if (!previousIds.includes(id) && !newVideoIds[id]) {
+              newVideoIds[id] = now;
+            }
+          });
+        }
+        sources[sourceKey] = mergeUnique(ids, previousIds);
+      });
+
+      return { sources, newVideoIds };
+    });
+  }, []);
+
+  const loadFeed = useCallback(async ({
+    queryText = activeQuery,
+    sourceId = activeSourceId,
+    pageNumber = 1,
+    append = false,
+    sourceSubscription: explicitSourceSubscription,
+  }: {
+    queryText?: string;
+    sourceId?: string | null;
+    pageNumber?: number;
+    append?: boolean;
+    sourceSubscription?: YouTubeSubscription | null;
+  } = {}) => {
+    if (!canUseProxy) return;
+    const requestId = loadRequestRef.current + 1;
+    loadRequestRef.current = requestId;
+    if (append) {
+      loadingMoreRef.current = true;
+      setIsLoadingMore(true);
+    } else {
+      loadingMoreRef.current = false;
+      setIsLoading(true);
+      setPage(1);
+    }
+    setError(null);
+    try {
+      const trimmedQuery = queryText.trim();
+      const sourceSubscription = sourceId
+        ? explicitSourceSubscription
+          ?? subscriptions.find((sub) => sub.id === sourceId)
+          ?? (transientSource && transientSource.id === sourceId ? transientSource : null)
+        : null;
+      const resolvedSourceSubscription = sourceSubscription ? normalizeSubscriptionForState(sourceSubscription) : null;
+      const feedSubscriptions = sourceSubscription ? [sourceSubscription] : subscriptions;
+      const feedKey = subscriptionKeyForList(feedSubscriptions);
+      const next = trimmedQuery
+        ? await youtubeProxySearch(trimmedQuery, settings.instance, pageNumber)
+        : await youtubeProxySubscriptionFeed(
+          resolvedSourceSubscription ? [resolvedSourceSubscription] : subscriptions.map(normalizeSubscriptionForState),
+          settings.instance,
+          pageNumber
+        );
+      if (requestId !== loadRequestRef.current) return;
+      if (append) {
+        setItems((prev) => {
+          const merged = mergeFeedItems(prev, next);
+          setHasMore(next.length > 0 && merged.added > 0);
+          return merged.items;
+        });
+      } else {
+        setItems(next);
+        setHasMore(next.length > 0);
+      }
+      setPage(pageNumber);
+      if (!trimmedQuery && !append && pageNumber === 1) {
+        rememberTimeline(next);
+        if (sourceId) {
+          lastAutoLoadKeyRef.current = `${feedKey}::${sourceId}`;
+        }
+      }
+    } catch (err) {
+      if (requestId !== loadRequestRef.current) return;
+      setError(toPersianErrorMessage(err));
+      if (!append) setItems([]);
+      setHasMore(false);
+      loadingMoreRef.current = false;
+    } finally {
+      if (requestId === loadRequestRef.current) {
+        setIsLoading(false);
+        setIsLoadingMore(false);
+        loadingMoreRef.current = false;
+      }
+    }
+  }, [activeQuery, activeSourceId, canUseProxy, rememberTimeline, settings.instance, subscriptions, transientSource]);
+
+  const refreshActiveView = useCallback(() => {
+    void loadFeed({
+      queryText: activeQuery,
+      sourceId: activeQuery.trim() ? null : activeSourceId,
+      pageNumber: 1,
+    });
+  }, [activeQuery, activeSourceId, loadFeed]);
+
+  const loadNextPage = useCallback(() => {
+    if (!canUseProxy || isLoading || isLoadingMore || loadingMoreRef.current || !hasMore || error || items.length === 0) return;
+    loadingMoreRef.current = true;
+    void loadFeed({
+      queryText: activeQuery,
+      sourceId: activeQuery.trim() ? null : activeSourceId,
+      pageNumber: page + 1,
+      append: true,
+    });
+  }, [activeQuery, activeSourceId, canUseProxy, error, hasMore, isLoading, isLoadingMore, items.length, loadFeed, page]);
+
+  useEffect(() => {
+    if (!canUseProxy) return;
+    if (activeQuery.trim()) return;
+    const autoLoadKey = `${subscriptionKey}::${activeSourceId ?? 'all'}`;
+    if (lastAutoLoadKeyRef.current === autoLoadKey) return;
+    lastAutoLoadKeyRef.current = autoLoadKey;
+    void loadFeed({ queryText: '', sourceId: activeSourceId, pageNumber: 1 });
+  }, [activeQuery, activeSourceId, canUseProxy, loadFeed, subscriptionKey]);
+
+  useEffect(() => {
+    if (!canUseProxy || activeQuery.trim()) return;
+    const id = window.setInterval(() => {
+      if (document.visibilityState === 'visible') {
+        void loadFeed({ queryText: '', sourceId: activeSourceId, pageNumber: 1 });
+      }
+    }, 10 * 60 * 1000);
+    return () => window.clearInterval(id);
+  }, [activeQuery, activeSourceId, canUseProxy, loadFeed]);
+
+  useEffect(() => {
+    if (
+      !activeSourceId ||
+      subscriptions.some((sub) => sub.id === activeSourceId) ||
+      transientSource?.id === activeSourceId
+    ) return;
+    setActiveSourceId(null);
+  }, [activeSourceId, subscriptions, transientSource]);
+
+  useEffect(() => {
+    const node = loadMoreRef.current;
+    if (!node || !canUseProxy || typeof IntersectionObserver === 'undefined') return;
+    const observer = new IntersectionObserver((entries) => {
+      if (entries.some((entry) => entry.isIntersecting)) {
+        loadNextPage();
+      }
+    }, { rootMargin: '720px 0px 720px' });
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [canUseProxy, loadNextPage]);
+
+  useEffect(() => {
+    if (!canUseProxy) return;
+    let cancelled = false;
+    const urls = Array.from(
+      new Set(items.map((item) => item.thumbnailUrl).filter((url): url is string => !!url))
+    ).filter((url) => !imageCache[url] && !failedImages[url]);
+    if (urls.length === 0) return;
+
+    const run = async () => {
+      const queue = [...urls];
+      const workers = Array.from({ length: Math.min(4, queue.length) }, async () => {
+        while (queue.length > 0 && !cancelled) {
+          const url = queue.shift();
+          if (!url) return;
+          try {
+            const dataUrl = await youtubeProxyImage(url, settings.instance);
+            if (cancelled) return;
+            setImageCache((prev) => ({ ...prev, [url]: dataUrl }));
+          } catch {
+            if (cancelled) return;
+            setFailedImages((prev) => ({ ...prev, [url]: true }));
+          }
+        }
+      });
+      await Promise.all(workers);
+    };
+
+    void run();
+    return () => {
+      cancelled = true;
+    };
+  }, [canUseProxy, failedImages, imageCache, items, settings.instance]);
+
+  const imageForItem = useCallback((item: YouTubeFeedItem) => {
+    return item.thumbnailUrl ? imageCache[item.thumbnailUrl] : undefined;
+  }, [imageCache]);
+
+  const isNewItem = useCallback((item: YouTubeFeedItem) => {
+    return Boolean(timelineMemory.newVideoIds[itemKey(item)]);
+  }, [timelineMemory.newVideoIds]);
+
+  const markItemSeen = useCallback((videoId: string) => {
+    setTimelineMemory((prev) => {
+      if (!prev.newVideoIds[videoId]) return prev;
+      const next = {
+        sources: prev.sources,
+        newVideoIds: { ...prev.newVideoIds },
+      };
+      delete next.newVideoIds[videoId];
+      return next;
+    });
+  }, []);
+
+  const openQueryFeed = useCallback((nextQuery: string) => {
+    const trimmed = nextQuery.trim();
+    setSelected(null);
+    setTransientSource(null);
+    setActiveSourceId(null);
+    setActiveQuery(trimmed);
+    setPage(1);
+    setHasMore(true);
+    void loadFeed({ queryText: trimmed, sourceId: null, pageNumber: 1 });
+  }, [loadFeed]);
+
+  const openSubscriptionFeed = useCallback(async (subscriptionId: string | null) => {
+    setSelected(null);
+    setActiveQuery('');
+    setTransientSource(null);
+    setPage(1);
+    setHasMore(true);
+    if (!subscriptionId) {
+      setActiveSourceId(null);
+      void loadFeed({ queryText: '', sourceId: null, pageNumber: 1 });
+      return;
+    }
+
+    const source = subscriptions.find((sub) => sub.id === subscriptionId) ?? null;
+    const normalizedSource = source ? normalizeSubscriptionForState(source) : null;
+    const input = source?.value.trim() || source?.label.trim() || '';
+    const shouldResolve = Boolean(
+      input && (
+        !normalizedSource ||
+        normalizedSource.kind === 'search' ||
+        (normalizedSource.kind === 'channel' && !channelIdForSubscription(normalizedSource))
+      )
+    );
+    if (shouldResolve) {
+      setError(null);
+      setIsLoading(true);
+      try {
+        const resolved = normalizeSubscriptionForState(
+          await youtubeProxyResolveSubscription(input, settings.instance)
+        );
+        if (resolved.kind === 'channel') {
+          setSubscriptions((prev) => {
+            const seen = new Set<string>();
+            const next = prev
+              .map((sub) => (sub.id === subscriptionId ? { ...resolved, addedAt: sub.addedAt || resolved.addedAt } : sub))
+              .map(normalizeSubscriptionForState)
+              .filter((sub) => {
+                const key = subscriptionDedupeKey(sub);
+                if (seen.has(key)) return false;
+                seen.add(key);
+                return true;
+              });
+            return subscriptionsEqual(prev, next) ? prev : next;
+          });
+          setActiveSourceId(resolved.id);
+          await loadFeed({
+            queryText: '',
+            sourceId: resolved.id,
+            pageNumber: 1,
+            sourceSubscription: resolved,
+          });
+          return;
+        }
+      } catch (err) {
+        setError(toPersianErrorMessage(err));
+        setItems([]);
+        setHasMore(false);
+        return;
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    setActiveSourceId(subscriptionId);
+    void loadFeed({
+      queryText: '',
+      sourceId: subscriptionId,
+      pageNumber: 1,
+      sourceSubscription: normalizedSource,
+    });
+  }, [loadFeed, settings.instance, subscriptions]);
+
+  const openTransientChannel = useCallback(async (channelId: string, label?: string) => {
+    if (!canUseProxy) return;
+    const term = (channelId || label || '').trim();
+    if (!term) return;
+    setSelected(null);
+    setError(null);
+    setIsLoading(true);
+    try {
+      const knownChannelId = /^UC[A-Za-z0-9_-]{22}$/.test(term);
+      const resolved = normalizeSubscriptionForState(
+        knownChannelId
+          ? {
+              id: `channel:${term}`,
+              kind: 'channel',
+              label: label?.trim() || term,
+              value: term,
+              channelId: term,
+              addedAt: new Date().toISOString(),
+            }
+          : await youtubeProxyResolveSubscription(term, settings.instance)
+      );
+      setTransientSource(resolved);
+      setActiveQuery('');
+      setActiveSourceId(resolved.id);
+      setPage(1);
+      setHasMore(true);
+      await loadFeed({
+        queryText: '',
+        sourceId: resolved.id,
+        pageNumber: 1,
+        sourceSubscription: resolved,
+      });
+    } catch (err) {
+      setError(toPersianErrorMessage(err));
+      setItems([]);
+      setHasMore(false);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [canUseProxy, loadFeed, settings.instance]);
+
+  const openSearchChannel = useCallback(async (item: YouTubeFeedItem) => {
+    if (!item.channelId && !item.channelTitle) return;
+    await openTransientChannel(item.channelId || item.channelTitle || '', item.channelTitle);
+  }, [openTransientChannel]);
+
+  const handleSearch = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    openQueryFeed(query);
+  };
+
+  const handleAddSubscription = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const input = subscriptionInput.trim();
+    if (!input || isAdding || !canUseProxy) return;
+    setIsAdding(true);
+    setError(null);
+    try {
+      const resolved = normalizeSubscriptionForState(
+        await youtubeProxyResolveSubscription(input, settings.instance)
+      );
+      setSubscriptions((prev) => {
+        const resolvedKey = subscriptionDedupeKey(resolved);
+        if (prev.some((s) => subscriptionDedupeKey(s) === resolvedKey)) return prev;
+        return [resolved, ...prev].map(normalizeSubscriptionForState).slice(0, 40);
+      });
+      setSubscriptionInput('');
+      setActiveQuery('');
+      setQuery('');
+      setTransientSource(null);
+    } catch (err) {
+      setError(toPersianErrorMessage(err));
+    } finally {
+      setIsAdding(false);
+    }
+  };
+
+  const handleDownload = async () => {
+    if (!selected || downloadDisabled) return;
+    setDrawerError(null);
+    try {
+      await submitDownload({
+        url: selected.url || youtubeWatchUrl(selected.videoId),
+        source: 'youtube',
+        quality: format === 'mp3' ? 'audio' : quality,
+        format: format === 'mp3' ? 'mp3' : 'mp4',
+        advanced: normalizedAdvanced,
+        archiveItems,
+      });
+      setSelected(null);
+    } catch (err) {
+      setDrawerError(toPersianErrorMessage(err));
+    }
+  };
+
+  return (
+    <section className="yt-workspace" dir="ltr">
+      <aside className="yt-sidebar" dir="rtl">
+        <div className="yt-panel-head">
+          <div>
+            <p className="yt-kicker">YouTube</p>
+            <h2>کانال‌ها و جستجوها</h2>
+          </div>
+          <button
+            type="button"
+            onClick={refreshActiveView}
+            disabled={!canUseProxy || isLoading || isLoadingMore}
+            title="تازه‌سازی"
+          >
+            <RefreshCw size={14} className={cn((isLoading || isLoadingMore) && 'animate-spin')} />
+          </button>
+        </div>
+
+        <form className="yt-sub-form" onSubmit={handleAddSubscription}>
+          <input
+            value={subscriptionInput}
+            onChange={(e) => setSubscriptionInput(e.target.value)}
+            placeholder="نام کانال، @handle یا لینک"
+            disabled={!canUseProxy || isAdding}
+            dir="auto"
+          />
+          <button type="submit" disabled={!canUseProxy || isAdding || !subscriptionInput.trim()} title="افزودن">
+            {isAdding ? <Loader2 size={14} className="animate-spin" /> : <Plus size={14} />}
+          </button>
+        </form>
+
+        <div className="yt-sub-list">
+          {subscriptions.length === 0 ? (
+            <div className="yt-empty-mini">برای شروع یک کانال یا عبارت جستجو اضافه کنید.</div>
+          ) : (
+            <>
+              <div
+                className={cn('yt-sub-row yt-sub-all', !activeQuery.trim() && activeSourceId == null && 'active')}
+                role="button"
+                tabIndex={0}
+                onClick={() => openSubscriptionFeed(null)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    openSubscriptionFeed(null);
+                  }
+                }}
+              >
+                <div>
+                  <strong>همه کانال‌ها</strong>
+                  <span>فید مشترک</span>
+                </div>
+              </div>
+              {subscriptions.map((sub) => (
+                <div
+                  className={cn('yt-sub-row', !activeQuery.trim() && activeSourceId === sub.id && 'active')}
+                  key={sub.id}
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => openSubscriptionFeed(sub.id)}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                      event.preventDefault();
+                      openSubscriptionFeed(sub.id);
+                    }
+                  }}
+                >
+                  <div>
+                    <strong dir="auto">{sub.label}</strong>
+                    <span>{sub.kind === 'channel' ? 'کانال' : 'جستجو'}</span>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      setSubscriptions((prev) => prev.filter((s) => s.id !== sub.id));
+                    }}
+                    title="حذف"
+                  >
+                    <Trash2 size={13} />
+                  </button>
+                </div>
+              ))}
+            </>
+          )}
+        </div>
+      </aside>
+
+      <div className="yt-main">
+        <form className="yt-search" onSubmit={handleSearch}>
+          <Search size={17} />
+          <input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="جستجوی ویدیو"
+            disabled={!canUseProxy}
+            dir="auto"
+          />
+          <button type="submit" disabled={!canUseProxy || isLoading}>
+            {isLoading ? '...' : 'جستجو'}
+          </button>
+        </form>
+
+        <div className="yt-feed-mode" dir="rtl">
+          <span dir="auto">{activeViewLabel}</span>
+          <button type="button" onClick={refreshActiveView} disabled={!canUseProxy || isLoading || isLoadingMore}>
+            تازه‌سازی
+          </button>
+        </div>
+
+        {!canUseProxy ? (
+          <div className="yt-state yt-state-warn" dir="rtl">
+            <AlertCircle size={18} />
+            <div>
+              <strong>فید یوتیوب فقط در نسخه دسکتاپ فعال است.</strong>
+              <p>برنامه دسکتاپ را اجرا کنید و دوباره وارد این بخش شوید.</p>
+            </div>
+          </div>
+        ) : error ? (
+          <div className="yt-state yt-state-warn" dir="rtl">
+            <AlertCircle size={18} />
+            <div>
+              <strong>فید بارگذاری نشد</strong>
+              <p>{error}</p>
+            </div>
+          </div>
+        ) : isLoading && items.length === 0 ? (
+          <div className="yt-state">
+            <Loader2 size={18} className="animate-spin" />
+            <span>در حال دریافت ویدیوها...</span>
+          </div>
+        ) : items.length === 0 ? (
+          <div className="yt-state" dir="rtl">
+            <span>ویدیویی برای نمایش نیست. جستجو کنید یا کانال اضافه کنید.</span>
+          </div>
+        ) : (
+          <>
+            <div className="yt-grid">
+              {items.map((item) => {
+                const imageSrc = imageForItem(item);
+                const hasImagePending = Boolean(item.thumbnailUrl && !imageSrc && !failedImages[item.thumbnailUrl]);
+                return (
+                  <article
+                    className="yt-card"
+                    key={itemKey(item)}
+                    onClick={() => {
+                      markItemSeen(item.videoId);
+                      setSelected(item);
+                    }}
+                  >
+                    <div className={cn('yt-thumb', hasImagePending && 'loading')}>
+                      {imageSrc ? (
+                        <img src={imageSrc} alt="" loading="lazy" />
+                      ) : (
+                        <div className="yt-thumb-empty">
+                          {hasImagePending ? <Loader2 size={20} className="animate-spin" /> : <ImageOff size={20} />}
+                        </div>
+                      )}
+                      {isNewItem(item) && <b className="yt-new-badge">NEW</b>}
+                      {item.duration && <span className="yt-duration">{item.duration}</span>}
+                    </div>
+                    <div className="yt-card-body">
+                      <h3 dir="auto">{item.title}</h3>
+                      <button
+                        type="button"
+                        className="yt-channel-link"
+                        dir="auto"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          void openSearchChannel(item);
+                        }}
+                        disabled={!item.channelId && !item.channelTitle}
+                      >
+                        {item.channelTitle}
+                      </button>
+                      <small>{[item.viewCountText, item.publishedAt].filter(Boolean).join(' · ')}</small>
+                    </div>
+                  </article>
+                );
+              })}
+            </div>
+            <div ref={loadMoreRef} className="yt-load-more" dir="rtl">
+              {isLoadingMore ? (
+                <>
+                  <Loader2 size={16} className="animate-spin" />
+                  <span>در حال دریافت ویدیوهای بیشتر...</span>
+                </>
+              ) : hasMore ? (
+                <button type="button" onClick={loadNextPage} disabled={!canUseProxy || isLoading}>
+                  نمایش بیشتر
+                </button>
+              ) : (
+                <span>ویدیوی بیشتری پیدا نشد.</span>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+
+      {selected && (
+        <div className="yt-drawer-backdrop" onClick={() => setSelected(null)}>
+          <aside className="yt-drawer" onClick={(e) => e.stopPropagation()} dir="rtl">
+            <button type="button" className="yt-drawer-close" onClick={() => setSelected(null)} title="بستن">
+              <X size={16} />
+            </button>
+            <div className="yt-drawer-thumb">
+              {imageForItem(selected) ? <img src={imageForItem(selected)} alt="" /> : <div><ImageOff size={24} /></div>}
+              {isNewItem(selected) && <b className="yt-new-badge">NEW</b>}
+            </div>
+            <h2 dir="auto">{selected.title}</h2>
+            <p dir="auto">{[selected.channelTitle, selected.viewCountText, selected.publishedAt].filter(Boolean).join(' · ')}</p>
+            <div className="yt-choice-row">
+              {FORMATS.map((opt) => (
+                <button
+                  key={opt.value}
+                  type="button"
+                  onClick={() => setFormat(opt.value)}
+                  className={cn(format === opt.value && 'active')}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+            <div className={cn('yt-choice-row', format === 'mp3' && 'disabled')}>
+              {QUALITIES.map((opt) => (
+                <button
+                  key={opt.value}
+                  type="button"
+                  onClick={() => setQuality(opt.value)}
+                  disabled={format === 'mp3'}
+                  className={cn(quality === opt.value && format !== 'mp3' && 'active')}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+            {drawerError && <div className="yt-drawer-error">{drawerError}</div>}
+            <button
+              type="button"
+              className="yt-download-btn"
+              onClick={() => void handleDownload()}
+              disabled={downloadDisabled}
+            >
+              {isSubmitting ? <Loader2 size={15} className="animate-spin" /> : <Download size={15} />}
+              <span>
+                {downloadBusy ? 'یک دانلود فعال است' : isSubmitting ? 'در حال ارسال' : 'ارسال برای دانلود'}
+              </span>
+            </button>
+          </aside>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1186,16 +1186,78 @@ body::after {
   margin: 0.25rem 0 1.5rem;
 }
 
-.reclip-header .ascii-logo,
-.reclip-header > :first-child {
+.reclip-header .ascii-logo {
   margin: 0 auto;
 }
 
-.settings-cog {
+.app-shell {
+  width: min(100%, 48rem);
+  max-width: 1180px;
+}
+
+.app-shell.feed-mode {
+  width: min(100%, 92rem);
+  max-width: 1480px;
+}
+
+.app-shell.feed-mode .reclip-header {
+  min-height: 38px;
+  margin: 0 0 0.7rem;
+  justify-content: flex-start;
+}
+
+.app-top-controls {
   position: fixed;
   right: 24px;
   top: 24px;
-  z-index: 80;
+  z-index: 90;
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+}
+
+.app-mode-switch {
+  display: inline-flex;
+  align-items: stretch;
+  border: 1px solid var(--cns-line);
+  background: rgba(8, 11, 9, 0.72);
+  backdrop-filter: blur(8px);
+  overflow: hidden;
+}
+
+.app-mode-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  min-height: 36px;
+  padding: 0 0.65rem;
+  border: 0;
+  border-inline-start: 1px solid var(--cns-line-soft);
+  background: transparent;
+  color: var(--cns-text);
+  font-family: 'Vazirmatn', 'JetBrains Mono', monospace;
+  font-size: 0.74rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.18s ease, color 0.18s ease;
+}
+
+.app-mode-btn:first-child {
+  border-inline-start: 0;
+}
+
+.app-mode-btn:hover {
+  color: var(--cns-text-bright);
+  background: rgba(195, 230, 215, 0.08);
+}
+
+.app-mode-btn.active {
+  color: var(--cns-text-bright);
+  background: rgba(184, 216, 204, 0.14);
+}
+
+.settings-cog {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1259,6 +1321,30 @@ body::after {
   background: rgba(255, 59, 59, 0.1);
 }
 
+.proxy-fallback-message {
+  display: none;
+  align-items: flex-start;
+  gap: 0.55rem;
+  margin-bottom: 1.1rem;
+  padding: 0.65rem 0.85rem;
+  border: 1px solid rgba(255, 180, 100, 0.35);
+  background: rgba(255, 180, 100, 0.05);
+  color: #f3d6a8;
+  font-size: 0.76rem;
+  line-height: 1.7;
+}
+
+.proxy-fallback-message svg {
+  flex: 0 0 auto;
+  margin-top: 0.15rem;
+}
+
+@media (min-width: 768px) {
+  .proxy-fallback-message {
+    display: flex;
+  }
+}
+
 .config-banner {
   display: flex;
   flex-wrap: wrap;
@@ -1289,6 +1375,482 @@ body::after {
 .config-banner-btn:hover {
   background: rgba(255, 180, 100, 0.18);
   color: #fff;
+}
+
+.settings-notice-chip {
+  display: inline-flex;
+  flex: 0 1 auto;
+  align-items: center;
+  gap: 0.45rem;
+  max-width: 12rem;
+  width: fit-content;
+  padding: 0.36rem 0.6rem;
+  border: 1px solid rgba(255, 180, 100, 0.38);
+  background: rgba(255, 180, 100, 0.08);
+  color: #f3d6a8;
+  font-size: 0.72rem;
+  line-height: 1.4;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  text-align: start;
+}
+
+.settings-notice-chip svg {
+  flex: 0 0 auto;
+  color: inherit;
+}
+
+.yt-workspace {
+  display: grid;
+  grid-template-columns: 320px minmax(0, 1fr);
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+  align-items: start;
+}
+
+.yt-sidebar,
+.yt-main,
+.yt-drawer {
+  border: 1px solid var(--cns-line);
+  background: linear-gradient(180deg, rgba(12, 16, 13, 0.98), rgba(6, 9, 7, 0.96));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.03),
+    0 24px 60px rgba(0, 0, 0, 0.35);
+}
+
+.yt-sidebar {
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  align-self: start;
+  position: sticky;
+  top: 1rem;
+  max-height: calc(100vh - 2rem);
+  overflow: auto;
+  overflow-x: hidden;
+}
+
+.yt-main {
+  padding: 1rem;
+  min-width: 0;
+}
+
+.yt-panel-head,
+.yt-search,
+.yt-sub-row,
+.yt-state,
+.yt-card,
+.yt-download-btn,
+.yt-drawer-close,
+.yt-choice-row button {
+  display: flex;
+  align-items: center;
+}
+
+.yt-panel-head {
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.yt-kicker {
+  margin: 0 0 0.2rem;
+  color: var(--cns-muted);
+  font-size: 0.68rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.yt-panel-head h2 {
+  margin: 0;
+  color: var(--cns-text-bright);
+  font-size: 0.95rem;
+}
+
+.yt-sub-form,
+.yt-search {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.55rem;
+}
+
+.yt-sub-form input,
+.yt-search input {
+  min-width: 0;
+  border: 1px solid var(--cns-line);
+  background: rgba(5, 5, 5, 0.35);
+  color: var(--cns-text-bright);
+  min-height: 42px;
+  padding: 0 0.9rem;
+  font-size: 0.8rem;
+}
+
+.yt-sub-form button,
+.yt-search button,
+.yt-panel-head button,
+.yt-drawer-close,
+.yt-download-btn {
+  border: 1px solid var(--cns-line);
+  background: rgba(195, 230, 215, 0.05);
+  color: var(--cns-text-bright);
+  cursor: pointer;
+}
+
+.yt-sub-form button,
+.yt-panel-head button {
+  width: 42px;
+  min-height: 42px;
+  display: grid;
+  place-items: center;
+}
+
+.yt-sub-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  overflow: auto;
+}
+
+.yt-sub-row {
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.72rem 0.75rem;
+  border: 1px solid rgba(100, 130, 118, 0.34);
+  background: rgba(195, 230, 215, 0.03);
+  cursor: pointer;
+  transition: border-color 0.18s ease, background 0.18s ease;
+}
+
+.yt-sub-row.active {
+  border-color: var(--cns-line-bright);
+  background: rgba(184, 216, 204, 0.1);
+}
+
+.yt-sub-row strong {
+  display: block;
+  color: var(--cns-text-bright);
+  font-size: 0.8rem;
+}
+
+.yt-sub-row span,
+.yt-empty-mini {
+  color: var(--cns-muted);
+  font-size: 0.72rem;
+}
+
+.yt-sub-row button {
+  border: 0;
+  background: transparent;
+  color: var(--cns-muted);
+}
+
+.yt-sub-row button:hover {
+  color: var(--cns-text-bright);
+}
+
+.yt-search {
+  margin-bottom: 0.9rem;
+  grid-template-columns: 42px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0;
+  overflow: hidden;
+  border: 1px solid var(--cns-line);
+  background: rgba(5, 5, 5, 0.35);
+}
+
+.yt-search svg {
+  justify-self: center;
+  color: var(--cns-muted);
+}
+
+.yt-search input {
+  border: 0;
+  background: transparent;
+}
+
+.yt-search button {
+  min-height: 42px;
+  min-width: 88px;
+  border-block: 0;
+  border-inline-end: 0;
+  padding: 0 0.95rem;
+}
+
+.yt-feed-mode {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+  color: var(--cns-muted);
+  font-size: 0.72rem;
+}
+
+.yt-feed-mode button {
+  border: 1px solid rgba(100, 130, 118, 0.34);
+  background: rgba(195, 230, 215, 0.03);
+  color: var(--cns-text);
+  padding: 0.35rem 0.6rem;
+  cursor: pointer;
+}
+
+.yt-feed-mode button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.yt-state {
+  gap: 0.65rem;
+  padding: 1rem;
+  border: 1px solid rgba(100, 130, 118, 0.34);
+  background: rgba(195, 230, 215, 0.03);
+  color: var(--cns-text-bright);
+}
+
+.yt-state-warn {
+  border-color: rgba(255, 180, 100, 0.34);
+  color: #f3d6a8;
+}
+
+.yt-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 0.7rem;
+}
+
+.yt-card {
+  min-width: 0;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0;
+  padding: 0;
+  border: 1px solid rgba(100, 130, 118, 0.26);
+  background: rgba(195, 230, 215, 0.025);
+  overflow: hidden;
+  cursor: pointer;
+  transition: border-color 0.18s ease, background 0.18s ease, transform 0.18s ease;
+}
+
+.yt-card:hover {
+  border-color: rgba(184, 216, 204, 0.42);
+  background: rgba(195, 230, 215, 0.045);
+  transform: translateY(-2px);
+}
+
+.yt-thumb {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  width: 100%;
+  max-width: none;
+  border: 1px solid rgba(100, 130, 118, 0.22);
+  border-width: 0 0 1px;
+  border-radius: 0;
+  overflow: hidden;
+  background: rgba(0, 0, 0, 0.35);
+}
+
+.yt-thumb img,
+.yt-drawer-thumb img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.yt-duration {
+  position: absolute;
+  right: 0.45rem;
+  bottom: 0.45rem;
+  padding: 0.2rem 0.35rem;
+  background: rgba(0, 0, 0, 0.76);
+  color: #fff;
+  font-size: 0.66rem;
+}
+
+.yt-new-badge {
+  position: absolute;
+  left: 0.5rem;
+  top: 0.5rem;
+  padding: 0.18rem 0.42rem;
+  border: 1px solid rgba(255, 80, 80, 0.55);
+  background: rgba(170, 20, 20, 0.88);
+  color: #fff;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.62rem;
+  line-height: 1.2;
+}
+
+.yt-thumb-empty,
+.yt-drawer-thumb div {
+  display: grid;
+  place-items: center;
+  width: 100%;
+  height: 100%;
+  color: var(--cns-text-bright);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.9rem;
+  background: linear-gradient(135deg, rgba(195, 230, 215, 0.06), rgba(255, 255, 255, 0.02));
+}
+
+.yt-card-body {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 0.35rem;
+  align-items: stretch;
+  padding: 0.7rem;
+}
+
+.yt-card-body h3 {
+  display: -webkit-box;
+  min-height: 0;
+  margin: 0;
+  overflow: hidden;
+  color: var(--cns-text-bright);
+  font-size: 0.92rem;
+  line-height: 1.38;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.yt-card-body small,
+.yt-channel-link {
+  display: block;
+  margin: 0;
+  color: var(--cns-muted);
+  font-size: 0.72rem;
+  line-height: 1.5;
+}
+
+.yt-channel-link {
+  width: 100%;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  text-align: start;
+  white-space: normal;
+  overflow: visible;
+  text-overflow: ellipsis;
+}
+
+.yt-channel-link:hover {
+  color: var(--cns-text-bright);
+}
+
+.yt-drawer-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 120;
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.yt-drawer {
+  position: relative;
+  width: min(420px, 100vw);
+  min-height: 100vh;
+  padding: 0.85rem;
+}
+
+.yt-drawer-close {
+  position: absolute;
+  top: 0.85rem;
+  left: 0.85rem;
+  width: 2rem;
+  height: 2rem;
+  justify-content: center;
+}
+
+.yt-drawer-thumb {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  margin-bottom: 0.9rem;
+  border: 1px solid rgba(100, 130, 118, 0.34);
+  overflow: hidden;
+}
+
+.yt-drawer h2 {
+  margin: 0 0 0.35rem;
+  color: var(--cns-text-bright);
+  font-size: 0.98rem;
+  line-height: 1.55;
+}
+
+.yt-drawer p {
+  margin: 0 0 0.75rem;
+  color: var(--cns-muted);
+  font-size: 0.75rem;
+}
+
+.yt-choice-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-bottom: 0.75rem;
+}
+
+.yt-choice-row button {
+  padding: 0.5rem 0.7rem;
+  border: 1px solid rgba(100, 130, 118, 0.34);
+  background: rgba(195, 230, 215, 0.03);
+  color: var(--cns-text);
+  font-size: 0.72rem;
+}
+
+.yt-choice-row button.active {
+  border-color: var(--cns-line-bright);
+  color: var(--cns-text-bright);
+  background: rgba(195, 230, 215, 0.1);
+}
+
+.yt-choice-row.disabled button {
+  opacity: 0.5;
+}
+
+.yt-drawer-error {
+  margin-bottom: 0.75rem;
+  color: #f3d6a8;
+  font-size: 0.72rem;
+}
+
+.yt-load-more {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.55rem;
+  min-height: 3rem;
+  margin-top: 0.75rem;
+  color: var(--cns-muted);
+  font-size: 0.72rem;
+}
+
+.yt-load-more button {
+  border: 1px solid rgba(100, 130, 118, 0.34);
+  background: rgba(195, 230, 215, 0.03);
+  color: var(--cns-text-bright);
+  padding: 0.45rem 0.8rem;
+  cursor: pointer;
+}
+
+.yt-load-more button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.yt-download-btn {
+  width: 100%;
+  justify-content: center;
+  gap: 0.45rem;
+  padding: 0.8rem 0.9rem;
+}
+
+.yt-download-btn:disabled,
+.yt-sub-form button:disabled,
+.yt-search button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
 }
 
 .fetch-shell {
@@ -2500,11 +3062,10 @@ select,
     justify-content: flex-start;
     margin-top: 0.25rem;
     margin-bottom: 1rem;
-    padding-inline-end: 4.8rem;
+    padding-inline-end: 0;
   }
 
-  .reclip-header .ascii-logo,
-  .reclip-header > :first-child {
+  .reclip-header .ascii-logo {
     margin: 0;
   }
 
@@ -2600,12 +3161,79 @@ select,
     inset-inline-end: 0.65rem;
   }
 
-  .settings-cog {
+  .app-top-controls {
     right: 12px;
     top: 12px;
+    left: 12px;
+    justify-content: flex-end;
+    gap: 0.4rem;
+  }
+
+  .settings-notice-chip {
+    max-width: 7.2rem;
+    padding: 0.32rem 0.45rem;
+    font-size: 0.66rem;
+  }
+
+  .app-mode-switch {
+    flex: 1 1 auto;
+    max-width: 11.5rem;
+  }
+
+  .app-mode-btn {
+    flex: 1;
+    min-width: 0;
+    padding: 0 0.45rem;
+    font-size: 0.68rem;
+  }
+
+  .settings-cog {
+    flex: 0 0 auto;
     height: 32px;
     padding: 0 0.55rem;
     font-size: 0.72rem;
+  }
+
+  .app-shell.feed-mode .reclip-header {
+    min-height: 34px;
+    margin-bottom: 0.65rem;
+    justify-content: flex-start;
+  }
+
+  .yt-workspace {
+    grid-template-columns: 1fr;
+    gap: 0.75rem;
+  }
+
+  .yt-sidebar,
+  .yt-main {
+    padding: 0.75rem;
+  }
+
+  .yt-sidebar {
+    position: static;
+    max-height: none;
+    overflow: visible;
+  }
+
+  .yt-search {
+    grid-template-columns: 38px minmax(0, 1fr);
+  }
+
+  .yt-search button {
+    grid-column: 1 / -1;
+    min-height: 38px;
+    border-inline-start: 0;
+    border-top: 1px solid var(--cns-line);
+  }
+
+  .yt-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .yt-drawer {
+    width: 100vw;
+    min-height: 100vh;
   }
 
   .cookie-warning {
@@ -2716,4 +3344,3 @@ select,
     flex-basis: auto;
   }
 }
-

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -199,6 +199,7 @@ function makeGithubRateLimitError(status: number, response: Response, apiMessage
 export type DownloadAdvancedContainer = 'default' | 'mp4' | 'webm' | 'mkv';
 export type DownloadAdvancedCodec = 'copy' | 'h264' | 'vp9' | 'hevc' | 'av1';
 export type DownloadAdvancedBitrate = 'auto' | '1M' | '3M' | '5M' | '8M';
+export type DownloadSource = 'youtube';
 
 export interface DownloadAdvancedOptions {
   container: DownloadAdvancedContainer;
@@ -228,6 +229,7 @@ const WORKFLOW_YML = DOWNLOAD_WORKFLOW_YML;
 export interface DownloadJob {
   id: string;
   url: string;
+  source?: DownloadSource;
   quality: string;
   format: string;
   advanced?: DownloadAdvancedOptions;
@@ -287,6 +289,7 @@ class GitHubClient {
     | ((command: string, payload?: Record<string, unknown>) => Promise<any>)
     | null {
     if (typeof window === 'undefined') return null;
+    if (typeof window.__TAURI__?.core?.invoke === 'function') return window.__TAURI__.core.invoke;
     if (typeof window.__TAURI__?.invoke === 'function') return window.__TAURI__.invoke;
     if (typeof window.__TAURI_INVOKE__ === 'function') return window.__TAURI_INVOKE__;
     if (typeof window.__TAURI__?.tauri?.invoke === 'function') return window.__TAURI__.tauri.invoke;
@@ -739,7 +742,8 @@ class GitHubClient {
     url: string,
     quality: string,
     format: string,
-    advanced: DownloadAdvancedOptions = DEFAULT_DOWNLOAD_ADVANCED
+    advanced: DownloadAdvancedOptions = DEFAULT_DOWNLOAD_ADVANCED,
+    source: DownloadSource = 'youtube'
   ): Promise<number> {
     const config = this.getConfig();
     if (!config) throw new CNSError('GitHub config not set', ErrorCodes.CONFIG_MISSING, false);
@@ -763,6 +767,7 @@ class GitHubClient {
       targetHost,
       quality,
       format,
+      source,
       advanced,
     });
 
@@ -831,6 +836,7 @@ class GitHubClient {
         targetHost,
         quality,
         format,
+        source,
       });
       return response.status;
     } catch (err) {
@@ -841,6 +847,7 @@ class GitHubClient {
         targetHost,
         quality,
         format,
+        source,
       });
       if (err instanceof CNSError) throw err;
       throw new CNSError(`Network error: ${err instanceof Error ? err.message : 'Unknown error'}`, ErrorCodes.NETWORK_ERROR, true);
@@ -852,9 +859,10 @@ class GitHubClient {
     quality: string,
     format: string,
     advanced: DownloadAdvancedOptions,
+    source: DownloadSource,
     timeoutMs: number
   ): Promise<number> {
-    const run = this.triggerWorkflow(url, quality, format, advanced);
+    const run = this.triggerWorkflow(url, quality, format, advanced, source);
     let timer = 0;
     const timeout = new Promise<number>((_, reject) => {
       timer = window.setTimeout(() => reject(new Error('Dispatch timeout')), timeoutMs);
@@ -870,11 +878,12 @@ class GitHubClient {
     url: string,
     quality: string,
     format: string,
-    advanced: DownloadAdvancedOptions = DEFAULT_DOWNLOAD_ADVANCED
+    advanced: DownloadAdvancedOptions = DEFAULT_DOWNLOAD_ADVANCED,
+    source: DownloadSource = 'youtube'
   ): Promise<{ status: number; dispatchAt: string; runHint: { afterTs: number; quality: string; format: string } }> {
     let lastErr: unknown = null;
     try {
-      const status = await this.triggerWorkflowWithTimeout(url, quality, format, advanced, 12000);
+      const status = await this.triggerWorkflowWithTimeout(url, quality, format, advanced, source, 12000);
       const now = Date.now();
       return {
         status,

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -459,7 +459,9 @@ class Logger {
   async exportToFile(): Promise<string> {
     const content = this.export();
     const invoke =
-      typeof window.__TAURI__?.invoke === 'function'
+      typeof window.__TAURI__?.core?.invoke === 'function'
+        ? window.__TAURI__!.core.invoke
+        : typeof window.__TAURI__?.invoke === 'function'
         ? window.__TAURI__!.invoke
         : typeof window.__TAURI_INVOKE__ === 'function'
           ? window.__TAURI_INVOKE__

--- a/src/lib/useDownloadSubmit.ts
+++ b/src/lib/useDownloadSubmit.ts
@@ -1,0 +1,198 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+import {
+  DownloadJob,
+  github,
+  DEFAULT_DOWNLOAD_ADVANCED,
+  type DownloadAdvancedOptions,
+  type DownloadSource,
+} from './github';
+import { toPersianErrorMessage } from './errors';
+import { logger } from './logger';
+
+const COOKIE_HASH_KEY = 'cns_cookie_hash_v1';
+
+function urlContentKey(raw: string): string {
+  try {
+    const u = new URL(raw.trim());
+    const host = u.hostname.replace(/^www\./i, '').toLowerCase();
+    if (host === 'youtu.be') {
+      const id = u.pathname.split('/').filter(Boolean)[0] || '';
+      return id ? `yt:${id}` : `url:${u.origin}${u.pathname}${u.search}`;
+    }
+    if (host === 'youtube.com' || host.endsWith('.youtube.com')) {
+      if (u.pathname === '/watch') {
+        const v = u.searchParams.get('v') || '';
+        if (v) return `yt:${v}`;
+      }
+      const p = u.pathname.split('/').filter(Boolean);
+      if (p[0] === 'shorts' && p[1]) return `yt:${p[1]}`;
+      if (p[0] === 'live' && p[1]) return `yt:${p[1]}`;
+    }
+    u.hash = '';
+    return `url:${u.toString()}`;
+  } catch {
+    return `raw:${raw.trim()}`;
+  }
+}
+
+async function fetchOembed(url: string): Promise<DownloadJob['meta']> {
+  try {
+    const resp = await fetch(`https://noembed.com/embed?url=${encodeURIComponent(url)}`);
+    if (!resp.ok) return undefined;
+    const data = await resp.json();
+    if (data?.error) return undefined;
+    return {
+      title: data.title,
+      channel: data.author_name,
+      thumbnail: data.thumbnail_url,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+async function sha1Hex(input: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-1', new TextEncoder().encode(input));
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function advancedSubmitKey(a: DownloadAdvancedOptions): string {
+  return `${a.container}|${a.codec}|${a.bitrate}`;
+}
+
+type SubmitDownloadArgs = {
+  url: string;
+  quality: string;
+  format: string;
+  source?: DownloadSource;
+  advanced?: DownloadAdvancedOptions;
+  archiveItems?: Array<{ metadata?: { original_url?: string } | undefined }>;
+};
+
+type SubmitDownloadHandlers = {
+  onAddPending: (job: DownloadJob) => void;
+  onPatchJob: (jobId: string, updates: Partial<DownloadJob>) => void;
+};
+
+export function useDownloadSubmit({ onAddPending, onPatchJob }: SubmitDownloadHandlers) {
+  const inFlightRef = useRef(new Set<string>());
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const submitDownload = useCallback(
+    async ({ url, quality, format, source = 'youtube', advanced = DEFAULT_DOWNLOAD_ADVANCED, archiveItems = [] }: SubmitDownloadArgs) => {
+      const normalizedUrl = url.trim();
+      if (!normalizedUrl) {
+        throw new Error('یک لینک معتبر وارد کنید');
+      }
+
+      const currentKey = urlContentKey(normalizedUrl);
+      const exists = archiveItems.some((a) => {
+        const original = a.metadata?.original_url;
+        if (!original) return false;
+        return urlContentKey(original) === currentKey;
+      });
+      if (exists) {
+        throw new Error('این ویدیو قبلا دانلود شده و داخل آرشیو موجود است.');
+      }
+
+      const config = github.getConfig();
+      if (!config) {
+        throw new Error('توکن گیت‌هاب تنظیم نشده است');
+      }
+
+      const effectiveQuality = quality;
+      const effectiveFormat = format;
+      const submitKey = `${source}|${normalizedUrl}|${effectiveQuality}|${effectiveFormat}|${advancedSubmitKey(advanced)}`;
+      if (inFlightRef.current.has(submitKey)) {
+        throw new Error('این درخواست هم‌اکنون در حال ارسال است.');
+      }
+      inFlightRef.current.add(submitKey);
+
+      setIsSubmitting(true);
+      try {
+        const net = await github.probeNetwork();
+        if (!net.ok) {
+          if (net.code === 'AUTH') {
+            throw new Error('توکن گیت‌هاب رد شد (۴۰۱). در تنظیمات دوباره ذخیره کنید.');
+          }
+          throw new Error('اتصال شبکه به GitHub برقرار نیست. فایروال/ DNS یا پروکسی سیستم را بررسی کنید.');
+        }
+
+        logger.info('[Download] Submit started', { source, format, quality, advanced });
+        const cookieHealth = github.assessStoredCookies();
+        if (!cookieHealth.ok) {
+          throw new Error(cookieHealth.reason || 'COOKIE_EXPIRED_LOCAL');
+        }
+        const cookies = github.getCookies();
+        if (cookies) {
+          const cookieHash = await sha1Hex(cookies);
+          const uploadedHash = sessionStorage.getItem(COOKIE_HASH_KEY);
+          if (uploadedHash !== cookieHash) {
+            await github.uploadCookies(cookies);
+            sessionStorage.setItem(COOKIE_HASH_KEY, cookieHash);
+          }
+        }
+
+        const nowIso = new Date().toISOString();
+        const jobId = crypto.randomUUID();
+        const baseJob: DownloadJob = {
+          id: jobId,
+          url: normalizedUrl,
+          source,
+          quality: effectiveQuality,
+          format: effectiveFormat,
+          advanced: { ...advanced },
+          status: 'pending',
+          progress: 0,
+          logs: [`[${new Date().toLocaleTimeString('fa-IR')}] صف شد`],
+          createdAt: nowIso,
+          submitKey,
+        };
+        onAddPending(baseJob);
+
+        const metaTask = source === 'youtube' ? fetchOembed(normalizedUrl) : Promise.resolve<DownloadJob['meta']>(undefined);
+        try {
+          const dispatch = await github.triggerWorkflowFast(normalizedUrl, effectiveQuality, effectiveFormat, advanced, source);
+          const fetchedMeta = await metaTask.catch(() => undefined);
+          const logs = [`[${new Date().toLocaleTimeString('fa-IR')}] صف شد`, `[${new Date().toLocaleTimeString('fa-IR')}] ارسال به گیت‌هاب انجام شد`];
+          onPatchJob(jobId, {
+            dispatchAt: dispatch.dispatchAt,
+            runHint: dispatch.runHint,
+            logs,
+            meta: fetchedMeta,
+          });
+          logger.info('[Download] Workflow dispatched', { source, format: effectiveFormat, quality: effectiveQuality, advanced });
+          return { jobId, dispatchAt: dispatch.dispatchAt };
+        } catch (err) {
+          logger.error('[Download] Dispatch failed', { error: err, source, format: effectiveFormat, quality: effectiveQuality });
+          const message = toPersianErrorMessage(err);
+          const fetchedMeta = await metaTask.catch(() => undefined);
+          onPatchJob(jobId, {
+            status: 'failed',
+            progress: 0,
+            logs: [`[${new Date().toLocaleTimeString('fa-IR')}] صف شد`, `[${new Date().toLocaleTimeString('fa-IR')}] ${message}`],
+            meta: fetchedMeta,
+          });
+          throw err instanceof Error ? err : new Error(message);
+        }
+      } catch (err) {
+        logger.error('[Download] Submit aborted', { error: err });
+        throw err;
+      } finally {
+        inFlightRef.current.delete(submitKey);
+        setIsSubmitting(false);
+      }
+    },
+    [onAddPending, onPatchJob]
+  );
+
+  return useMemo(
+    () => ({
+      submitDownload,
+      isSubmitting,
+    }),
+    [submitDownload, isSubmitting]
+  );
+}

--- a/src/lib/youtubeProxy.ts
+++ b/src/lib/youtubeProxy.ts
@@ -1,0 +1,160 @@
+import { logger } from './logger';
+
+export const DEFAULT_INVIDIOUS_INSTANCE = 'https://invidious.tiekoetter.com';
+const SUBSCRIPTIONS_STORAGE_KEY = 'cns_youtube_subscriptions_v1';
+const SETTINGS_STORAGE_KEY = 'cns_youtube_proxy_settings_v1';
+
+declare global {
+  interface Window {
+    __TAURI__?: any;
+    __TAURI_INVOKE__?: (command: string, payload?: any) => Promise<any>;
+  }
+}
+
+export interface YouTubeSubscription {
+  id: string;
+  kind: 'channel' | 'search';
+  label: string;
+  value: string;
+  channelId?: string;
+  thumbnail?: string;
+  addedAt: string;
+}
+
+export interface YouTubeFeedItem {
+  videoId: string;
+  title: string;
+  channelTitle: string;
+  channelId?: string;
+  thumbnailUrl?: string;
+  publishedAt?: string;
+  duration?: string;
+  viewCountText?: string;
+  sourceId?: string;
+  url: string;
+}
+
+export interface YouTubeProxySettings {
+  instance: string;
+}
+
+function getTauriInvoke(): ((command: string, payload?: Record<string, unknown>) => Promise<any>) | null {
+  if (typeof window === 'undefined') return null;
+  if (typeof window.__TAURI__?.core?.invoke === 'function') return window.__TAURI__.core.invoke;
+  if (typeof window.__TAURI__?.invoke === 'function') return window.__TAURI__.invoke;
+  if (typeof window.__TAURI_INVOKE__ === 'function') return window.__TAURI_INVOKE__;
+  if (typeof window.__TAURI__?.tauri?.invoke === 'function') return window.__TAURI__.tauri.invoke;
+  return null;
+}
+
+export function isYoutubeProxyAvailable(): boolean {
+  return getTauriInvoke() != null;
+}
+
+function safeParse<T>(raw: string | null, fallback: T): T {
+  if (!raw) return fallback;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+function normalizeSettings(raw: unknown): YouTubeProxySettings {
+  if (!raw || typeof raw !== 'object') return { instance: DEFAULT_INVIDIOUS_INSTANCE };
+  const instance = (raw as Record<string, unknown>).instance;
+  return {
+    instance: normalizeInstanceInput(instance),
+  };
+}
+
+function normalizeInstanceInput(raw: unknown): string {
+  const normalized = typeof raw === 'string' ? raw.trim() : '';
+  const withScheme = normalized && !/^https?:\/\//i.test(normalized) ? `https://${normalized}` : normalized;
+  return /^https?:\/\//i.test(withScheme) ? withScheme : DEFAULT_INVIDIOUS_INSTANCE;
+}
+
+function normalizeSubscription(raw: unknown): YouTubeSubscription | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const o = raw as Record<string, unknown>;
+  if (typeof o.id !== 'string' || typeof o.label !== 'string' || typeof o.value !== 'string') return null;
+  const kind = o.kind === 'channel' || o.kind === 'search' ? o.kind : 'search';
+  return {
+    id: o.id,
+    kind,
+    label: o.label,
+    value: o.value,
+    channelId: typeof o.channelId === 'string' ? o.channelId : undefined,
+    thumbnail: typeof o.thumbnail === 'string' ? o.thumbnail : undefined,
+    addedAt: typeof o.addedAt === 'string' ? o.addedAt : new Date().toISOString(),
+  };
+}
+
+export function loadYoutubeProxySettings(): YouTubeProxySettings {
+  try {
+    return normalizeSettings(safeParse(localStorage.getItem(SETTINGS_STORAGE_KEY), null));
+  } catch {
+    return { instance: DEFAULT_INVIDIOUS_INSTANCE };
+  }
+}
+
+export function saveYoutubeProxySettings(settings: YouTubeProxySettings) {
+  try {
+    localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(normalizeSettings(settings)));
+  } catch {
+  }
+}
+
+export function loadYoutubeSubscriptions(): YouTubeSubscription[] {
+  try {
+    const raw = safeParse<unknown>(localStorage.getItem(SUBSCRIPTIONS_STORAGE_KEY), []);
+    if (!Array.isArray(raw)) return [];
+    return raw.map(normalizeSubscription).filter((s): s is YouTubeSubscription => s != null);
+  } catch {
+    return [];
+  }
+}
+
+export function saveYoutubeSubscriptions(items: YouTubeSubscription[]) {
+  try {
+    localStorage.setItem(SUBSCRIPTIONS_STORAGE_KEY, JSON.stringify(items.slice(0, 40)));
+  } catch {
+  }
+}
+
+async function invokeProxy<T>(command: string, payload: Record<string, unknown>): Promise<T> {
+  const invoke = getTauriInvoke();
+  if (!invoke) {
+    throw new Error('CNS desktop app is required for this feed.');
+  }
+  try {
+    return (await invoke(command, payload)) as T;
+  } catch (err) {
+    logger.warn('[YouTubeFeed] command failed', { command, error: err });
+    throw err;
+  }
+}
+
+export async function youtubeProxyHealth(instance: string): Promise<{ ok: boolean; message?: string }> {
+  return invokeProxy('yt_proxy_health', { instance: normalizeInstanceInput(instance) });
+}
+
+export async function youtubeProxySearch(query: string, instance: string, page?: number): Promise<YouTubeFeedItem[]> {
+  return invokeProxy('yt_proxy_search', { query, instance: normalizeInstanceInput(instance), page });
+}
+
+export async function youtubeProxyResolveSubscription(input: string, instance: string): Promise<YouTubeSubscription> {
+  return invokeProxy('yt_proxy_resolve_subscription', { input, instance: normalizeInstanceInput(instance) });
+}
+
+export async function youtubeProxySubscriptionFeed(
+  subscriptions: YouTubeSubscription[],
+  instance: string,
+  page?: number,
+): Promise<YouTubeFeedItem[]> {
+  return invokeProxy('yt_proxy_subscription_feed', { subscriptions, instance: normalizeInstanceInput(instance), page });
+}
+
+export async function youtubeProxyImage(url: string, instance: string): Promise<string> {
+  return invokeProxy('yt_proxy_image', { url, instance: normalizeInstanceInput(instance) });
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,5 +5,6 @@ export default defineConfig({
   plugins: [react()],
   server: {
     port: 3000,
+    strictPort: true,
   },
 })


### PR DESCRIPTION

## Summary

  Adds a desktop YouTube feed mode to CNS, so users can search/browse videos, follow channels or searches,
  and send selected videos directly into the existing GitHub Actions download flow.

  This keeps the original link-based download workflow intact while adding a richer discovery path inside
  the Tauri desktop app.

  ## What Changed

  - Added a new YouTube Feed mode alongside the existing console download mode
  - Added feed search, channel/search subscriptions, refresh, pagination, and new-video markers
  - Added video detail drawer with format/quality selection and direct download submission
  - Added Tauri-side proxy commands for fetching feed/search/channel data and thumbnails
  - Added thumbnail caching for the desktop feed experience
  - Extracted download submission logic into a shared hook used by both console and feed flows
  - Preserved existing archive/job tracking behavior for submitted downloads
  - Defaulted console video quality to `480p`
  - Added supporting UI styles for the feed, drawer, source list, and responsive layout

  ## Screenshot

<img width="1696" height="1001" alt="demo" src="https://github.com/user-attachments/assets/33e15f7b-5155-4b53-b16b-7632b1dc5abc" />


  ## Notes

  - The feed mode depends on the Tauri desktop shell because it uses native commands for proxy fetches and
  image caching.
  - Existing direct-link download behavior remains available in console mode.
  - GitHub token and YouTube cookie handling are unchanged from the existing settings flow.

